### PR TITLE
[Channel Tables] Preserve order of channels

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -127,6 +127,10 @@ define([
             aboutHtml: insertBuildInfo(AboutTemplate),
         });
 
+        // do not show telemetry if it falls out of bounds
+        // even if there is no new telemetry
+        openmct.telemetry.greedyLAD(false);
+
         persistenceLoadedPromise.then(() => {
             openmct.start();
             window.openmct = openmct;

--- a/src/channelTable/channelTablePlugin/ChannelTable.js
+++ b/src/channelTable/channelTablePlugin/ChannelTable.js
@@ -35,14 +35,11 @@ define([
             this.tableRows = new ChannelTableRowCollection(this.openmct);
 
             let sortOptions = this.configuration.getConfiguration().sortOptions;
-
-            //If no persisted sort order, default to sorting by time system, ascending.
-            sortOptions = sortOptions || {
-                key: this.openmct.time.timeSystem().key,
-                direction: 'asc'
-            };
     
-            this.tableRows.sortBy(sortOptions);
+            if (sortOptions) {
+                this.tableRows.sortBy(sortOptions);
+            }
+
             this.tableRows.on('resetRowsFromAllData', this.resetRowsFromAllData);
         }
 

--- a/src/channelTable/channelTablePlugin/ChannelTableRowCollection.js
+++ b/src/channelTable/channelTablePlugin/ChannelTableRowCollection.js
@@ -48,9 +48,7 @@ define(
 
                 if (this.isNewerThanLAD(item)) {
                     let rowIndex = this.ladMap.get(item.objectKeyString);
-                    let itemToReplace = this.rows[rowIndex];
                     this.rows[rowIndex] = item;
-                    this.emit('remove', [itemToReplace]);
                     this.emit('add', [item]);
                     return true;
                 }

--- a/src/channelTable/channelTablePlugin/ChannelTableRowCollection.js
+++ b/src/channelTable/channelTablePlugin/ChannelTableRowCollection.js
@@ -23,7 +23,6 @@ define(
 
             addOrUpdateRow(row) {
                 if (this.isLADRow(row)) {
-                    this.removeExistingByKeystring(row.objectKeyString);
                     this.addRows([row]);
                 }
             }
@@ -49,6 +48,7 @@ define(
                 if (this.isNewerThanLAD(item)) {
                     let rowIndex = this.ladMap.get(item.objectKeyString);
                     this.rows[rowIndex] = item;
+                    this.removeExistingByKeystring(item.objectKeyString);
                     this.emit('add', [item]);
                     return true;
                 }
@@ -58,9 +58,8 @@ define(
             addRows(rows) {
                 let rowsToAdd = this.filterRows(rows);
 
-                rowsToAdd.forEach(this.addOne.bind(this));
-
                 if (rowsToAdd.length > 0) {
+                    rowsToAdd.forEach(this.addOne.bind(this));
                     this.emit('add', rowsToAdd);
                 }
             }

--- a/src/channelTable/channelTablePlugin/ChannelTableRowCollection.js
+++ b/src/channelTable/channelTablePlugin/ChannelTableRowCollection.js
@@ -23,8 +23,8 @@ define(
 
             addOrUpdateRow(row) {
                 if (this.isLADRow(row)) {
-                    this.removeRowsByObject(row.objectKeyString);
-                    super.addRows([row], 'add');
+                    this.removeExistingByKeystring(row.objectKeyString);
+                    this.addRows([row]);
                 }
             }
 
@@ -38,7 +38,7 @@ define(
                 return !isStaleData;
             }
 
-            addOne (item) {
+            addOne(item) {
                 if (item.isDummyRow) {
                     this.ladMap.set(item.objectKeyString, this.rows.length);
                     this.rows.push(item);
@@ -57,9 +57,35 @@ define(
                 return false;
             }
 
+            addRows(rows) {
+                let rowsToAdd = this.filterRows(rows);
+
+                rowsToAdd.forEach(this.addOne.bind(this));
+
+                if (rowsToAdd.length > 0) {
+                    this.emit('add', rowsToAdd);
+                }
+            }
+
             removeAllRowsForObject(objectKeyString) {
                 super.removeAllRowsForObject(objectKeyString);
                 this.rebuildLadMap();
+            }
+
+            removeExistingByKeystring(keyString) {
+                let removed = [];
+
+                this.rows.forEach((row) => {
+                    if (row.objectKeyString === keyString) {
+                        removed.push(row);
+
+                        return false;
+                    } else {
+                        return true;
+                    }
+                });
+
+                this.emit('remove', removed);
             }
 
             rebuildLadMap() {
@@ -69,7 +95,7 @@ define(
                 });
             }
 
-            reorder (reorderPlan) {
+            reorder(reorderPlan) {
                 let oldRows = this.rows.slice();
                 reorderPlan.forEach(reorderEvent => {
                     let item = oldRows[reorderEvent.oldIndex];

--- a/src/services/mcws/MIO.js
+++ b/src/services/mcws/MIO.js
@@ -78,8 +78,7 @@ export default class MIO {
     }
 
     async getMetadata() {
-        const response = await this.request(this.metadataUrl, 'GET', { output: 'json' });
-        const metadataResponse = await response.json();
+        const metadataResponse = await this.request(this.metadataUrl, 'GET', { output: 'json' });
                 
         return {
             get(subject, predicate) {


### PR DESCRIPTION
Overriding TableRowCollections `addRows` method to avoid sorting and to instead use the ChannelTableRowCollections `addRow` method, which handles replacing existing rows with new data, preserving the original order of the items. Also, no removing the rows directly, but emitting which rows are moved, because we handle row replacement in the `addRow` method.

Fixes issue where metadata was being `.json()`'d twice causing an error and preventing the correct version of MCWS to be set.

Sets `greedyLAD` to false, to turn off a new feature in core Open MCT that would show telemetry if it falls out of the set time bounds if no new telemetry has come in to replace it (only affects LAD requests).

Address subtask in #11 