### PR TITLE
Adding abort signal for object and telemetry requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "mini-css-extract-plugin": "2.6.0",
     "moment": "2.29.4",
     "node-bourbon": "^4.2.3",
-    "openmct": "nasa/openmct#omm-release/5.0",
+    "openmct": "nasa/openmct#omm-release/5.1",
     "openmct-legacy-support": "akhenry/openmct-legacy-support#omm-release/5.0",
     "printj": "^1.2.1",
     "raw-loader": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmct-mcws",
-  "version": "5.1.0-rc3",
+  "version": "5.1.0-rc1",
   "description": "Open MCT for MCWS",
   "devDependencies": {
     "axios": "^0.21.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmct-mcws",
-  "version": "5.1.0-rc1",
+  "version": "5.1.0-rc3",
   "description": "Open MCT for MCWS",
   "devDependencies": {
     "axios": "^0.21.2",
@@ -31,7 +31,7 @@
     "mini-css-extract-plugin": "2.6.0",
     "moment": "2.29.4",
     "node-bourbon": "^4.2.3",
-    "openmct": "nasa/openmct#omm-r5.1.0-rc1",
+    "openmct": "nasa/openmct#omm-r5.1.0-rc3",
     "openmct-legacy-support": "akhenry/openmct-legacy-support#omm-r5.1.0-rc1",
     "printj": "^1.2.1",
     "raw-loader": "^0.5.1",

--- a/src/historical/HistoricalProvider.js
+++ b/src/historical/HistoricalProvider.js
@@ -34,6 +34,7 @@ define([
         batchRequest: function (batch) {
             const requests = _.values(batch.requestsById);
             const params = requests[0].params;
+            const options = requests[0].options;
 
             params.lad_type = params.sort;
             params.select = '(dn,eu,channel_id,ert,scet,sclk,lst,record_type,dn_alarm_state,eu_alarm_state,module,realtime,dss_id)'
@@ -89,6 +90,7 @@ define([
         batchRequest: function (batch) {
             const requests = _.values(batch.requestsById);
             const params = requests[0].params;
+            const options = requests[0].options;
 
             params.minmax = '(' +
                 [

--- a/src/historical/HistoricalProvider.js
+++ b/src/historical/HistoricalProvider.js
@@ -51,7 +51,7 @@ define([
                 requestURL = ladURL;
             }
 
-            mcws.dataTable(requestURL, options.signal)
+            mcws.dataTable(requestURL, { signal: options.signal })
                 .read(params)
                 .then(function (res) {
                     const valuesByChannelId = _.groupBy(res, 'channel_id');
@@ -101,7 +101,7 @@ define([
             params.filter.channel_id__in = _.map(requests, 'domainObject.telemetry.channel_id');
             setSortFilter(params);
 
-            mcws.dataTable(requests[0].domainObject.telemetry.channelMinMaxUrl, options.signal)
+            mcws.dataTable(requests[0].domainObject.telemetry.channelMinMaxUrl, { signal: options.signal })
                 .read(params)
                 .then(function (res) {
                     const valuesByChannelId = _.groupBy(res, 'channel_id');
@@ -167,7 +167,7 @@ define([
 
             setSortFilter(params);
 
-            return mcws.dataTable(url, options.signal)
+            return mcws.dataTable(url, { signal: options.signal })
                 .read(params);
         }
     }, {
@@ -180,7 +180,7 @@ define([
             setMaxResults(domainObject, options, params);
             setSortFilter(params);
 
-            const promise = mcws.dataTable(domainObject.telemetry.dataProductUrl, options.signal)
+            const promise = mcws.dataTable(domainObject.telemetry.dataProductUrl, { signal: options.signal })
                 .read(params);
 
             if (domainObject.type === 'vista.dataProducts') {
@@ -229,7 +229,7 @@ define([
                     domainObject.telemetry.alarmLevel.toUpperCase();
             }
 
-            const dataTable = mcws.dataTable(domainObject.telemetry.channelHistoricalUrl, options.signal);
+            const dataTable = mcws.dataTable(domainObject.telemetry.channelHistoricalUrl, { signal: options.signal });
 
             return Promise.all([
                 dataTable.read(dnQueryParams),
@@ -258,7 +258,7 @@ define([
             delete params.filter[options.domain + '__gte'];
             delete params.filter[options.domain + '__lte'];
 
-            return mcws.dataTable(domainObject.telemetry.commandEventUrl, options.signal)
+            return mcws.dataTable(domainObject.telemetry.commandEventUrl, { signal: options.signal })
                 .read(params)
                 .then(function (res) {
                     return res;
@@ -279,7 +279,7 @@ define([
             setMaxResults(domainObject, options, params);
             setSortFilter(params);
 
-            return mcws.dataTable(domainObject.telemetry.channelHistoricalUrl, options.signal)
+            return mcws.dataTable(domainObject.telemetry.channelHistoricalUrl, { signal: options.signal })
                 .read(params);
         }
     }];
@@ -301,7 +301,7 @@ define([
             params.filter.channel_id__in = _.map(requests, 'domainObject.telemetry.channel_id');
             setSortFilter(params);
 
-            mcws.dataTable(requests[0].domainObject.telemetry.channelHistoricalUrl, options.signal)
+            mcws.dataTable(requests[0].domainObject.telemetry.channelHistoricalUrl, { signal: options.signal })
                 .read(params)
                 .then(function (res) {
                     const valuesByChannelId = _.groupBy(res, 'channel_id');
@@ -323,7 +323,7 @@ define([
             setSortFilter(params);
             setMaxResults(domainObject, options, params);
 
-            return mcws.dataTable(domainObject.telemetry.channelHistoricalUrl, options.signal)
+            return mcws.dataTable(domainObject.telemetry.channelHistoricalUrl, { signal: options.signal })
                 .read(params);
         }
     };

--- a/src/historical/HistoricalProvider.js
+++ b/src/historical/HistoricalProvider.js
@@ -51,7 +51,7 @@ define([
                 requestURL = ladURL;
             }
 
-            mcws.dataTable(requestURL)
+            mcws.dataTable(requestURL, options.signal)
                 .read(params)
                 .then(function (res) {
                     const valuesByChannelId = _.groupBy(res, 'channel_id');
@@ -101,7 +101,7 @@ define([
             params.filter.channel_id__in = _.map(requests, 'domainObject.telemetry.channel_id');
             setSortFilter(params);
 
-            mcws.dataTable(requests[0].domainObject.telemetry.channelMinMaxUrl)
+            mcws.dataTable(requests[0].domainObject.telemetry.channelMinMaxUrl, options.signal)
                 .read(params)
                 .then(function (res) {
                     const valuesByChannelId = _.groupBy(res, 'channel_id');
@@ -167,7 +167,7 @@ define([
 
             setSortFilter(params);
 
-            return mcws.dataTable(url)
+            return mcws.dataTable(url, options.signal)
                 .read(params);
         }
     }, {
@@ -180,7 +180,7 @@ define([
             setMaxResults(domainObject, options, params);
             setSortFilter(params);
 
-            const promise = mcws.dataTable(domainObject.telemetry.dataProductUrl)
+            const promise = mcws.dataTable(domainObject.telemetry.dataProductUrl, options.signal)
                 .read(params);
 
             if (domainObject.type === 'vista.dataProducts') {
@@ -229,7 +229,7 @@ define([
                     domainObject.telemetry.alarmLevel.toUpperCase();
             }
 
-            const dataTable = mcws.dataTable(domainObject.telemetry.channelHistoricalUrl);
+            const dataTable = mcws.dataTable(domainObject.telemetry.channelHistoricalUrl, options.signal);
 
             return Promise.all([
                 dataTable.read(dnQueryParams),
@@ -258,7 +258,7 @@ define([
             delete params.filter[options.domain + '__gte'];
             delete params.filter[options.domain + '__lte'];
 
-            return mcws.dataTable(domainObject.telemetry.commandEventUrl)
+            return mcws.dataTable(domainObject.telemetry.commandEventUrl, options.signal)
                 .read(params)
                 .then(function (res) {
                     return res;
@@ -279,7 +279,7 @@ define([
             setMaxResults(domainObject, options, params);
             setSortFilter(params);
 
-            return mcws.dataTable(domainObject.telemetry.channelHistoricalUrl)
+            return mcws.dataTable(domainObject.telemetry.channelHistoricalUrl, options.signal)
                 .read(params);
         }
     }];
@@ -301,7 +301,7 @@ define([
             params.filter.channel_id__in = _.map(requests, 'domainObject.telemetry.channel_id');
             setSortFilter(params);
 
-            mcws.dataTable(requests[0].domainObject.telemetry.channelHistoricalUrl)
+            mcws.dataTable(requests[0].domainObject.telemetry.channelHistoricalUrl, options.signal)
                 .read(params)
                 .then(function (res) {
                     const valuesByChannelId = _.groupBy(res, 'channel_id');
@@ -323,7 +323,7 @@ define([
             setSortFilter(params);
             setMaxResults(domainObject, options, params);
 
-            return mcws.dataTable(domainObject.telemetry.channelHistoricalUrl)
+            return mcws.dataTable(domainObject.telemetry.channelHistoricalUrl, options.signal)
                 .read(params);
         }
     };

--- a/src/persistence/MCWSPersistenceProvider.js
+++ b/src/persistence/MCWSPersistenceProvider.js
@@ -151,13 +151,13 @@ export default class MCWSPersistenceProvider {
         return domainObject;
     }
 
-    async #getNamespace(persistenceSpace, abortSignal) {
+    async #getNamespace(persistenceSpace, options) {
         const persistenceNamespaces = await this.getPersistenceNamespaces();
         const persistenceNamespace = persistenceNamespaces.find((namespace) => {
             return namespace.key === persistenceSpace;
         })
         
-        return mcws.namespace(persistenceNamespace.url, abortSignal);
+        return mcws.namespace(persistenceNamespace.url, options);
     }
 
     /**

--- a/src/persistence/MCWSPersistenceProvider.js
+++ b/src/persistence/MCWSPersistenceProvider.js
@@ -91,7 +91,7 @@ export default class MCWSPersistenceProvider {
             return createModelFromNamespaceDefinition('system', containerNamespace, containedNamespaceIdentifiers);
         }
 
-        const persistenceNamespace = await this.#getNamespace(namespace);
+        const persistenceNamespace = await this.#getNamespace(namespace, abortSignal);
 
         try {
             let result = await persistenceNamespace.opaqueFile(key).read();
@@ -146,13 +146,13 @@ export default class MCWSPersistenceProvider {
         return domainObject;
     }
 
-    async #getNamespace(persistenceSpace) {
+    async #getNamespace(persistenceSpace, abortSignal) {
         const persistenceNamespaces = await this.getPersistenceNamespaces();
         const persistenceNamespace = persistenceNamespaces.find((namespace) => {
             return namespace.key === persistenceSpace;
         })
         
-        return mcws.namespace(persistenceNamespace.url);
+        return mcws.namespace(persistenceNamespace.url, abortSignal);
     }
 
     /**

--- a/src/persistence/MCWSPersistenceProvider.js
+++ b/src/persistence/MCWSPersistenceProvider.js
@@ -79,6 +79,7 @@ export default class MCWSPersistenceProvider {
      */
     async get(identifier, abortSignal) {
         const { key, namespace } = identifier;
+        const options = {};
         
         // check if it is a namespace that has subnamespaces, if so, we return this item dynamically
         if (identifier.key === 'container') {
@@ -91,7 +92,11 @@ export default class MCWSPersistenceProvider {
             return createModelFromNamespaceDefinition('system', containerNamespace, containedNamespaceIdentifiers);
         }
 
-        const persistenceNamespace = await this.#getNamespace(namespace, abortSignal);
+        if (abortSignal) {
+            options.signal = abortSignal;
+        }
+
+        const persistenceNamespace = await this.#getNamespace(namespace, options);
 
         try {
             let result = await persistenceNamespace.opaqueFile(key).read();

--- a/src/services/mcws/DataTableMIO.js
+++ b/src/services/mcws/DataTableMIO.js
@@ -17,8 +17,8 @@ import MIO from './MIO';
  */
 
 class DataTableMIO extends MIO {
-    constructor(url) {
-        super(url);
+    constructor(url, abortSignal) {
+        super(url, abortSignal);
 
         this.type = 'datatable';
     }

--- a/src/services/mcws/DataTableMIO.js
+++ b/src/services/mcws/DataTableMIO.js
@@ -18,8 +18,9 @@ import MIO from './MIO';
 
 class DataTableMIO extends MIO {
     constructor(url, abortSignal) {
-        super(url, abortSignal);
+        super(url);
 
+        this.abortSignal = abortSignal;
         this.type = 'datatable';
     }
 

--- a/src/services/mcws/DataTableMIO.js
+++ b/src/services/mcws/DataTableMIO.js
@@ -17,10 +17,10 @@ import MIO from './MIO';
  */
 
 class DataTableMIO extends MIO {
-    constructor(url, abortSignal) {
+    constructor(url, options) {
         super(url);
 
-        this.abortSignal = abortSignal;
+        this.options = options;
         this.type = 'datatable';
     }
 

--- a/src/services/mcws/MIO.js
+++ b/src/services/mcws/MIO.js
@@ -74,8 +74,8 @@ export default class MIO {
             options.body = JSON.stringify(body);
         }
 
-        if (this.abortSignal) {
-            options.signal = this.abortSignal;
+        if (this.options?.signal) {
+            options.signal = this.options.signal;
         }
 
         return mcwsClient.request(options);

--- a/src/services/mcws/MIO.js
+++ b/src/services/mcws/MIO.js
@@ -14,13 +14,14 @@ import mcwsClient from './MCWSClient';
  * @param url the url for this MIO.
  */
 export default class MIO {
-    constructor(url = '') {
+    constructor(url = '', abortSignal) {
         if (url.endsWith('/')) {
             url = url.slice(0, -1);
         }
 
         this.url = url;
         this.metadataUrl = `${url}/`;
+        this.abortSignal = abortSignal;
 
         const pathParts = url.split('/');
         this.name = pathParts[pathParts.length - 1];
@@ -72,6 +73,10 @@ export default class MIO {
 
         if (body) {
             options.body = JSON.stringify(body);
+        }
+
+        if (this.abortSignal) {
+            options.signal = this.abortSignal;
         }
 
         return mcwsClient.request(options);

--- a/src/services/mcws/MIO.js
+++ b/src/services/mcws/MIO.js
@@ -78,7 +78,13 @@ export default class MIO {
             options.signal = this.options.signal;
         }
 
-        return mcwsClient.request(options);
+        return mcwsClient.request(options)
+            .catch(error => {
+                // suppress abort errors
+                if (error.name !== 'AbortError') {
+                    throw error;
+                }
+            });
     }
 
     async getMetadata() {

--- a/src/services/mcws/MIO.js
+++ b/src/services/mcws/MIO.js
@@ -14,14 +14,13 @@ import mcwsClient from './MCWSClient';
  * @param url the url for this MIO.
  */
 export default class MIO {
-    constructor(url = '', abortSignal) {
+    constructor(url = '') {
         if (url.endsWith('/')) {
             url = url.slice(0, -1);
         }
 
         this.url = url;
         this.metadataUrl = `${url}/`;
-        this.abortSignal = abortSignal;
 
         const pathParts = url.split('/');
         this.name = pathParts[pathParts.length - 1];

--- a/src/services/mcws/NamespaceMIO.js
+++ b/src/services/mcws/NamespaceMIO.js
@@ -15,8 +15,9 @@ import DataTableMIO from './DataTableMIO';
  */
 class NamespaceMIO extends MIO {
     constructor(url, abortSignal) {
-        super(url, abortSignal);
+        super(url);
 
+        this.abortSignal = abortSignal;
         this.type = 'namespace';
     }
 
@@ -45,8 +46,8 @@ class NamespaceMIO extends MIO {
      * @param {string} name the name of the MIO
      * @returns {OpaqueFileMIO} a handle to the opaque file
      */
-    opaqueFile(name, abortSignal) {
-        return new OpaqueFileMIO(`${this.url}/${name}`, abortSignal);
+    opaqueFile(name) {
+        return new OpaqueFileMIO(`${this.url}/${name}`, this.abortSignal);
     }
 
     /**
@@ -63,8 +64,8 @@ class NamespaceMIO extends MIO {
     * @param {string} namespace the namespace to utilize
     * @returns {NamespaceMIO} a handle to that namespace
     */
-    namespace(name, abortSignal) {
-        return new NamespaceMIO(`${this.url}/${name}`, abortSignal);
+    namespace(name) {
+        return new NamespaceMIO(`${this.url}/${name}`, this.abortSignal);
     }
 
     /**
@@ -78,8 +79,8 @@ class NamespaceMIO extends MIO {
     * @param {string} datatable the datatable to utilize
     * @returns {DataTableMIO} a handle to that datatable
     */
-    dataTable(name, abortSignal) {
-        return new DataTableMIO(`${this.url}/${name}`, abortSignal);
+    dataTable(name) {
+        return new DataTableMIO(`${this.url}/${name}`, this.abortSignal);
     }
 
     /**

--- a/src/services/mcws/NamespaceMIO.js
+++ b/src/services/mcws/NamespaceMIO.js
@@ -14,8 +14,8 @@ import DataTableMIO from './DataTableMIO';
  * @augments MIO
  */
 class NamespaceMIO extends MIO {
-    constructor(url) {
-        super(url);
+    constructor(url, abortSignal) {
+        super(url, abortSignal);
 
         this.type = 'namespace';
     }
@@ -45,8 +45,8 @@ class NamespaceMIO extends MIO {
      * @param {string} name the name of the MIO
      * @returns {OpaqueFileMIO} a handle to the opaque file
      */
-    opaqueFile(name) {
-        return new OpaqueFileMIO(`${this.url}/${name}`);
+    opaqueFile(name, abortSignal) {
+        return new OpaqueFileMIO(`${this.url}/${name}`, abortSignal);
     }
 
     /**
@@ -63,8 +63,8 @@ class NamespaceMIO extends MIO {
     * @param {string} namespace the namespace to utilize
     * @returns {NamespaceMIO} a handle to that namespace
     */
-    namespace(name) {
-        return new NamespaceMIO(`${this.url}/${name}`);
+    namespace(name, abortSignal) {
+        return new NamespaceMIO(`${this.url}/${name}`, abortSignal);
     }
 
     /**
@@ -78,8 +78,8 @@ class NamespaceMIO extends MIO {
     * @param {string} datatable the datatable to utilize
     * @returns {DataTableMIO} a handle to that datatable
     */
-    dataTable(name) {
-        return new DataTableMIO(`${this.url}/${name}`);
+    dataTable(name, abortSignal) {
+        return new DataTableMIO(`${this.url}/${name}`, abortSignal);
     }
 
     /**

--- a/src/services/mcws/NamespaceMIO.js
+++ b/src/services/mcws/NamespaceMIO.js
@@ -14,10 +14,10 @@ import DataTableMIO from './DataTableMIO';
  * @augments MIO
  */
 class NamespaceMIO extends MIO {
-    constructor(url, abortSignal) {
+    constructor(url, options) {
         super(url);
 
-        this.abortSignal = abortSignal;
+        this.options = options;
         this.type = 'namespace';
     }
 
@@ -47,7 +47,7 @@ class NamespaceMIO extends MIO {
      * @returns {OpaqueFileMIO} a handle to the opaque file
      */
     opaqueFile(name) {
-        return new OpaqueFileMIO(`${this.url}/${name}`, this.abortSignal);
+        return new OpaqueFileMIO(`${this.url}/${name}`, this.options);
     }
 
     /**
@@ -65,7 +65,7 @@ class NamespaceMIO extends MIO {
     * @returns {NamespaceMIO} a handle to that namespace
     */
     namespace(name) {
-        return new NamespaceMIO(`${this.url}/${name}`, this.abortSignal);
+        return new NamespaceMIO(`${this.url}/${name}`, this.options);
     }
 
     /**
@@ -80,7 +80,7 @@ class NamespaceMIO extends MIO {
     * @returns {DataTableMIO} a handle to that datatable
     */
     dataTable(name) {
-        return new DataTableMIO(`${this.url}/${name}`, this.abortSignal);
+        return new DataTableMIO(`${this.url}/${name}`, this.options);
     }
 
     /**

--- a/src/services/mcws/OpaqueFileMIO.js
+++ b/src/services/mcws/OpaqueFileMIO.js
@@ -17,10 +17,10 @@ import MIO from './MIO';
  */
 
 class OpaqueFileMIO extends MIO {
-    constructor(url, abortSignal) {
+    constructor(url, options) {
         super(url);
 
-        this.abortSignal = abortSignal;
+        this.options = options;
         this.type = 'opaque_file';
     }
 

--- a/src/services/mcws/OpaqueFileMIO.js
+++ b/src/services/mcws/OpaqueFileMIO.js
@@ -20,7 +20,7 @@ class OpaqueFileMIO extends MIO {
     constructor(url, abortSignal) {
         super(url);
 
-        this.
+        this.abortSignal = abortSignal;
         this.type = 'opaque_file';
     }
 

--- a/src/services/mcws/OpaqueFileMIO.js
+++ b/src/services/mcws/OpaqueFileMIO.js
@@ -17,8 +17,8 @@ import MIO from './MIO';
  */
 
 class OpaqueFileMIO extends MIO {
-    constructor(url) {
-        super(url);
+    constructor(url, abortSignal) {
+        super(url, abortSignal);
 
         this.type = 'opaque_file';
     }

--- a/src/services/mcws/OpaqueFileMIO.js
+++ b/src/services/mcws/OpaqueFileMIO.js
@@ -18,8 +18,9 @@ import MIO from './MIO';
 
 class OpaqueFileMIO extends MIO {
     constructor(url, abortSignal) {
-        super(url, abortSignal);
+        super(url);
 
+        this.
         this.type = 'opaque_file';
     }
 

--- a/src/services/mcws/mcws.js
+++ b/src/services/mcws/mcws.js
@@ -12,16 +12,16 @@ class MCWS {
         client.configure(config);
     }
 
-    namespace(name) {
-        return new NamespaceMIO(name);
+    namespace(name, abortSignal) {
+        return new NamespaceMIO(name, abortSignal);
     }
 
-    dataTable(name) {
-        return new DataTableMIO(name);
+    dataTable(name, abortSignal) {
+        return new DataTableMIO(name, abortSignal);
     }
 
-    opaqueFile(name) {
-        return new OpaqueFileMIO(name);
+    opaqueFile(name, abortSignal) {
+        return new OpaqueFileMIO(name, abortSignal);
     }
 }
 

--- a/src/services/mcws/mcws.js
+++ b/src/services/mcws/mcws.js
@@ -12,16 +12,16 @@ class MCWS {
         client.configure(config);
     }
 
-    namespace(name, abortSignal) {
-        return new NamespaceMIO(name, abortSignal);
+    namespace(name, options) {
+        return new NamespaceMIO(name, options);
     }
 
-    dataTable(name, abortSignal) {
-        return new DataTableMIO(name, abortSignal);
+    dataTable(name, options) {
+        return new DataTableMIO(name, options);
     }
 
-    opaqueFile(name, abortSignal) {
-        return new OpaqueFileMIO(name, abortSignal);
+    opaqueFile(name, options) {
+        return new OpaqueFileMIO(name, options);
     }
 }
 


### PR DESCRIPTION
Open MCT has the ability to cancel object requests (from the tree if a folder is closed before objects have been loaded) and telemetry requests (canceled when navigating away from a view that has requested telemetry). These changes hook that functionality up to the Historical Provider and the Persistence Provider in OMM.