### PR TITLE
[Persistence] Removes required user namespace and inability to manipulate older objects

### DIFF
--- a/src/persistence/existingNamespaceUpdateInterceptor.js
+++ b/src/persistence/existingNamespaceUpdateInterceptor.js
@@ -6,31 +6,33 @@ export default function existingNamespaceUpdateInterceptor(openmct, usersNamespa
             return shouldCheck;
         },
         invoke: (identifier, object) => {
+            // check for old user namespace style
             if (object.location === usersNamespace.key) {
                 object.location = usersNamespace.id;
                 openmct.objects.mutate(object, 'location', usersNamespace.id);
+            }
 
-                if (object.composition?.length) {
-                    let updatedComposition = false;
+            // check for old composition style
+            if (object.composition?.length) {
+                let updatedComposition = false;
 
-                    object.composition = object.composition.map((keystring) => {
-                        if (typeof keystring === 'string') {
-                            updatedComposition = true;
+                object.composition = object.composition.map((keystring) => {
+                    if (typeof keystring === 'string') {
+                        updatedComposition = true;
 
-                            const parts = keystring.split(':', 2);
+                        const parts = keystring.split(':', 2);
 
-                            return {
-                                namespace: parts[0],
-                                key: parts[1]
-                            }
+                        return {
+                            namespace: parts[0],
+                            key: parts[1]
                         }
-
-                        return keystring;
-                    });
-
-                    if (updatedComposition) {
-                        openmct.objects.mutate(object, 'composition', object.composition);
                     }
+
+                    return keystring;
+                });
+
+                if (updatedComposition) {
+                    openmct.objects.mutate(object, 'composition', object.composition);
                 }
             }
 

--- a/src/persistence/existingNamespaceUpdateInterceptor.js
+++ b/src/persistence/existingNamespaceUpdateInterceptor.js
@@ -20,12 +20,7 @@ export default function existingNamespaceUpdateInterceptor(openmct, usersNamespa
                     if (typeof keystring === 'string') {
                         updatedComposition = true;
 
-                        const parts = keystring.split(':', 2);
-
-                        return {
-                            namespace: parts[0],
-                            key: parts[1]
-                        }
+                        return openmct.objects.parseKeyString(keystring);
                     }
 
                     return keystring;

--- a/src/persistence/existingNamespaceUpdateInterceptor.js
+++ b/src/persistence/existingNamespaceUpdateInterceptor.js
@@ -11,8 +11,12 @@ export default function existingNamespaceUpdateInterceptor(openmct, usersNamespa
                 openmct.objects.mutate(object, 'location', usersNamespace.id);
 
                 if (object.composition?.length) {
-                    object.composition.map((keystring) => {
+                    let updatedComposition = false;
+
+                    object.composition = object.composition.map((keystring) => {
                         if (typeof keystring === 'string') {
+                            updatedComposition = true;
+
                             const parts = keystring.split(':', 2);
 
                             return {
@@ -23,6 +27,10 @@ export default function existingNamespaceUpdateInterceptor(openmct, usersNamespa
 
                         return keystring;
                     });
+
+                    if (updatedComposition) {
+                        openmct.objects.mutate(object, 'composition', object.composition);
+                    }
                 }
             }
 

--- a/src/persistence/existingNamespaceUpdateInterceptor.js
+++ b/src/persistence/existingNamespaceUpdateInterceptor.js
@@ -9,6 +9,21 @@ export default function existingNamespaceUpdateInterceptor(openmct, usersNamespa
             if (object.location === usersNamespace.key) {
                 object.location = usersNamespace.id;
                 openmct.objects.mutate(object, 'location', usersNamespace.id);
+
+                if (object.composition?.length) {
+                    object.composition.map((keystring) => {
+                        if (typeof keystring === 'string') {
+                            const parts = keystring.split(':', 2);
+
+                            return {
+                                namespace: parts[0],
+                                key: parts[1]
+                            }
+                        }
+
+                        return keystring;
+                    });
+                }
             }
 
             // turn off if we've checked the user folder

--- a/src/persistence/plugin.js
+++ b/src/persistence/plugin.js
@@ -14,7 +14,7 @@ export default function MCWSPersistenceProviderPlugin(configNamespaces) {
 
         const usersNamespace = namespaces.find((namespace) => namespace.containsNamespaces);
 
-        // user namespases are not required
+        // user namespaces are not required
         if (usersNamespace) {
             const checkOldNamespaces = localStorage.getItem(`r5.0_old_namespace_checked:${usersNamespace.key}`) === null;
             existingNamespaceUpdateInterceptor(openmct, usersNamespace, checkOldNamespaces);

--- a/src/persistence/plugin.js
+++ b/src/persistence/plugin.js
@@ -13,8 +13,12 @@ export default function MCWSPersistenceProviderPlugin(configNamespaces) {
         const mcwsPersistenceProvider = new MCWSPersistenceProvider(openmct, namespaces);
 
         const usersNamespace = namespaces.find((namespace) => namespace.containsNamespaces);
-        const checkOldNamespaces = localStorage.getItem(`r5.0_old_namespace_checked:${usersNamespace.key}`) === null;
-        existingNamespaceUpdateInterceptor(openmct, usersNamespace, checkOldNamespaces);
+
+        // user namespases are not required
+        if (usersNamespace) {
+            const checkOldNamespaces = localStorage.getItem(`r5.0_old_namespace_checked:${usersNamespace.key}`) === null;
+            existingNamespaceUpdateInterceptor(openmct, usersNamespace, checkOldNamespaces);
+        }
 
         // install the provider for each persistence space,
         // key is the namespace in the response for persistence namespaces

--- a/src/persistence/utils.js
+++ b/src/persistence/utils.js
@@ -9,7 +9,6 @@ export function createModelFromNamespaceDefinition(userId, namespaceDefinition, 
     const model = {
         identifier: createIdentifierFromNamespaceDefinition(namespaceDefinition),
         name: namespaceDefinition.name,
-        creatable: false,
         createdBy: userId,
         created: Date.now(),
         persisted: Date.now(),

--- a/src/persistence/utils.js
+++ b/src/persistence/utils.js
@@ -9,6 +9,7 @@ export function createModelFromNamespaceDefinition(userId, namespaceDefinition, 
     const model = {
         identifier: createIdentifierFromNamespaceDefinition(namespaceDefinition),
         name: namespaceDefinition.name,
+        creatable: false,
         createdBy: userId,
         created: Date.now(),
         persisted: Date.now(),


### PR DESCRIPTION
closes #55 
closes #59

This fix makes it so you can have an instance of OMM that doesn't have a user namespace configured. This also fixes an issue where you were unable to delete older instance objects (pre 5.0) due to mismatching composition formats.