### PR TITLE
[Persistence] Fix "missing" empty user folders from older persistence

### DIFF
--- a/src/persistence/MCWSPersistenceProvider.js
+++ b/src/persistence/MCWSPersistenceProvider.js
@@ -203,12 +203,8 @@ export default class MCWSPersistenceProvider {
         if (containedNamespaces.length) {
             containedNamespaces.forEach(async namespaceDefinition => {
                 const identifier = createIdentifierFromNamespaceDefinition(namespaceDefinition);
-
-                try {
-                    await this.get(identifier);
-                } catch (error) {
-                    console.log('error', error);
-                }
+                const userFolder = await this.get(identifier);
+                console.log('user folder', userFolder);
             });
         }
 

--- a/src/persistence/MCWSPersistenceProvider.js
+++ b/src/persistence/MCWSPersistenceProvider.js
@@ -2,6 +2,7 @@ import mcws from '../services/mcws/mcws';
 import {
   createModelFromNamespaceDefinition,
   createIdentifierFromNamespaceDefinition,
+  createModelFromNamespaceDefinitionWithPersisted,
   interpolateUsername
 } from './utils';
 
@@ -93,7 +94,7 @@ export default class MCWSPersistenceProvider {
             const containedNamespaces = await this.getContainedNamespaces(containerNamespace);
             const containedNamespaceIdentifiers = containedNamespaces.map(createIdentifierFromNamespaceDefinition);
 
-            return createModelFromNamespaceDefinition('system', containerNamespace, containedNamespaceIdentifiers);
+            return createModelFromNamespaceDefinitionWithPersisted('system', containerNamespace, containedNamespaceIdentifiers);
         }
 
         if (abortSignal) {
@@ -321,8 +322,9 @@ export default class MCWSPersistenceProvider {
                     await namespace.create();
 
                     if (!namespaceDefinition.id.endsWith('container')) {
-                        const model = createModelFromNamespaceDefinition(userId, namespaceDefinition);
-                        await this.openmct.objects.save(model);
+                        const INCLUDE_PERSISTENCE_TIME = true;
+                        const model = createModelFromNamespaceDefinitionWithPersisted(userId, namespaceDefinition, []);
+                        await this.create(model);
                     }
 
                     return namespaceDefinition;

--- a/src/persistence/MCWSPersistenceProvider.js
+++ b/src/persistence/MCWSPersistenceProvider.js
@@ -1,5 +1,9 @@
 import mcws from '../services/mcws/mcws';
-import { createModelFromNamespaceDefinition, createIdentifierFromNamespaceDefinition, interpolateUsername } from './utils';
+import {
+  createModelFromNamespaceDefinition,
+  createIdentifierFromNamespaceDefinition,
+  interpolateUsername
+} from './utils';
 
 const USERNAME_FROM_PATH_REGEX = new RegExp('.*/(.*?)$');
 

--- a/src/persistence/MCWSPersistenceProvider.js
+++ b/src/persistence/MCWSPersistenceProvider.js
@@ -203,8 +203,12 @@ export default class MCWSPersistenceProvider {
         if (containedNamespaces.length) {
             containedNamespaces.forEach(async namespaceDefinition => {
                 const identifier = createIdentifierFromNamespaceDefinition(namespaceDefinition);
-                const userFolder = await this.get(identifier);
-                console.log('user folder', userFolder);
+                const userRoot = await this.get(identifier);
+                
+                if (!userRoot) {
+                    const model = createModelFromNamespaceDefinition(user.id, namespaceDefinition);
+                    await this.create(model);
+                }
             });
         }
 

--- a/src/persistence/MCWSPersistenceProvider.js
+++ b/src/persistence/MCWSPersistenceProvider.js
@@ -199,6 +199,19 @@ export default class MCWSPersistenceProvider {
         const userNamespace = this.interpolateUsername(namespaceTemplate, user.id);
         const existingUserNamespace = containedNamespaces.find(namespace => namespace.url === userNamespace.url);
 
+        // need to check for any legacy empty user folders
+        if (containedNamespaces.length) {
+            containedNamespaces.forEach(namespaceDefinition => {
+                const identifier = createIdentifierFromNamespaceDefinition(namespaceDefinition);
+
+                try {
+                    this.get(identifier);
+                } catch (error) {
+                    console.log('error', error);
+                }
+            });
+        }
+
         if (existingUserNamespace) {
             containedNamespaces.splice(containedNamespaces.indexOf(existingUserNamespace), 1);
             containedNamespaces.unshift(userNamespace);

--- a/src/persistence/MCWSPersistenceProvider.js
+++ b/src/persistence/MCWSPersistenceProvider.js
@@ -322,7 +322,7 @@ export default class MCWSPersistenceProvider {
 
                     if (!namespaceDefinition.id.endsWith('container')) {
                         const model = createModelFromNamespaceDefinition(userId, namespaceDefinition);
-                        await this.create(model);
+                        await this.openmct.objects.save(model);
                     }
 
                     return namespaceDefinition;

--- a/src/persistence/MCWSPersistenceProvider.js
+++ b/src/persistence/MCWSPersistenceProvider.js
@@ -322,7 +322,6 @@ export default class MCWSPersistenceProvider {
                     await namespace.create();
 
                     if (!namespaceDefinition.id.endsWith('container')) {
-                        const INCLUDE_PERSISTENCE_TIME = true;
                         const model = createModelFromNamespaceDefinitionWithPersisted(userId, namespaceDefinition, []);
                         await this.create(model);
                     }

--- a/src/persistence/MCWSPersistenceProvider.js
+++ b/src/persistence/MCWSPersistenceProvider.js
@@ -202,12 +202,17 @@ export default class MCWSPersistenceProvider {
         // need to check for any legacy empty user folders
         if (containedNamespaces.length) {
             containedNamespaces.forEach(async namespaceDefinition => {
-                const identifier = createIdentifierFromNamespaceDefinition(namespaceDefinition);
-                const userRoot = await this.get(identifier);
-                
-                if (!userRoot) {
-                    const model = createModelFromNamespaceDefinition(user.id, namespaceDefinition);
-                    await this.create(model);
+                if (localStorage.getItem(`r5.0_empty_namespace_checked:${namespaceDefinition.key}`) === null) {
+                    // only one check
+                    localStorage.setItem(`r5.0_empty_namespace_checked:${namespaceDefinition.key}`, 'true');
+
+                    const identifier = createIdentifierFromNamespaceDefinition(namespaceDefinition);
+                    const userRoot = await this.get(identifier);
+                    
+                    if (!userRoot) {
+                        const model = createModelFromNamespaceDefinition(user.id, namespaceDefinition);
+                        await this.create(model);
+                    }
                 }
             });
         }

--- a/src/persistence/MCWSPersistenceProvider.js
+++ b/src/persistence/MCWSPersistenceProvider.js
@@ -201,11 +201,11 @@ export default class MCWSPersistenceProvider {
 
         // need to check for any legacy empty user folders
         if (containedNamespaces.length) {
-            containedNamespaces.forEach(namespaceDefinition => {
+            containedNamespaces.forEach(async namespaceDefinition => {
                 const identifier = createIdentifierFromNamespaceDefinition(namespaceDefinition);
 
                 try {
-                    this.get(identifier);
+                    await this.get(identifier);
                 } catch (error) {
                     console.log('error', error);
                 }

--- a/src/persistence/missingUserFolderInterceptor.js
+++ b/src/persistence/missingUserFolderInterceptor.js
@@ -13,7 +13,7 @@ export default function missingUserFolderInterceptor(openmct, usersNamespace) {
         invoke: (identifier, object) => {
             const userId = identifier.namespace.match(userKeyCheck)[1];
             const userNamespaceDefinition = interpolateUsername(usersNamespace.childTemplate, userId);
-            userNamespaceDefinition.location = userNamespaceDefinition.id;
+            userNamespaceDefinition.location = usersNamespace.id;
             const model = createModelFromNamespaceDefinition(userId, userNamespaceDefinition);
             
             openmct.objects.save(model);

--- a/src/persistence/missingUserFolderInterceptor.js
+++ b/src/persistence/missingUserFolderInterceptor.js
@@ -7,7 +7,7 @@ export default function missingUserFolderInterceptor(openmct, usersNamespace) {
     openmct.objects.addGetInterceptor({
         appliesTo: (identifier, domainObject) => {
             console.log('usersNamespace', usersNamespace);
-            console.log(domainObject.name, !domainObject && userKeyCheck.test(identifier.key));
+            console.log(identifier, !domainObject && userKeyCheck.test(identifier.key));
             return !domainObject && userKeyCheck.test(identifier.key);
         },
         invoke: (identifier, object) => {

--- a/src/persistence/missingUserFolderInterceptor.js
+++ b/src/persistence/missingUserFolderInterceptor.js
@@ -7,11 +7,11 @@ export default function missingUserFolderInterceptor(openmct, usersNamespace) {
     openmct.objects.addGetInterceptor({
         appliesTo: (identifier, domainObject) => {
             console.log('usersNamespace', usersNamespace);
-            console.log(identifier, !domainObject && userKeyCheck.test(identifier.key));
-            return !domainObject && userKeyCheck.test(identifier.key);
+            console.log(identifier, !domainObject && userKeyCheck.test(identifier.namespace));
+            return !domainObject && userKeyCheck.test(identifier.namespace);
         },
         invoke: (identifier, object) => {
-            const userId = identifier.key.match(pattern)[1];
+            const userId = identifier.namespace.match(pattern)[1];
             const userNamespaceDefinition = interpolateUsername(usersNamespace.childTemplate, userId);
             userNamespaceDefinition.location = userNamespaceDefinition.id;
             const model = createModelFromNamespaceDefinition(userId, userNamespaceDefinition);

--- a/src/persistence/missingUserFolderInterceptor.js
+++ b/src/persistence/missingUserFolderInterceptor.js
@@ -6,6 +6,8 @@ export default function missingUserFolderInterceptor(openmct, usersNamespace) {
 
     openmct.objects.addGetInterceptor({
         appliesTo: (identifier, domainObject) => {
+            console.log('usersNamespace', usersNamespace);
+            console.log(domainObject.name, !domainObject && userKeyCheck.test(identifier.key));
             return !domainObject && userKeyCheck.test(identifier.key);
         },
         invoke: (identifier, object) => {

--- a/src/persistence/missingUserFolderInterceptor.js
+++ b/src/persistence/missingUserFolderInterceptor.js
@@ -2,7 +2,7 @@ import { createModelFromNamespaceDefinition, interpolateUsername } from './utils
 
 export default function missingUserFolderInterceptor(openmct, usersNamespace) {
     const userTemplate = usersNamespace.childTemplate.key.split('$')[0];
-    const userKeyCheck = new RegExp(`^${userTemplate}[^:]+$`);
+    const userKeyCheck = new RegExp(`^${userTemplate}([^:]+)$`);
 
     openmct.objects.addGetInterceptor({
         appliesTo: (identifier, domainObject) => {

--- a/src/persistence/missingUserFolderInterceptor.js
+++ b/src/persistence/missingUserFolderInterceptor.js
@@ -1,0 +1,18 @@
+import { createModelFromNamespaceDefinition, interpolateUsername } from './utils';
+
+export default function missingUserFolderInterceptor(openmct, usersNamespace) {
+    const userTemplate = usersNamespace.childTemplate.key.split('$')[0];
+    const userKeyCheck = new RegExp(`^${userTemplate}[^:]+$`);
+
+    openmct.objects.addGetInterceptor({
+        appliesTo: (identifier, domainObject) => {
+            return !domainObject && userKeyCheck.test(identifier.key);
+        },
+        invoke: (identifier, object) => {
+            const userId = identifier.key.match(pattern)[1];
+            const model = createModelFromNamespaceDefinition(userId, namespaceDefinition);
+            
+            return object;
+        }
+    });
+}

--- a/src/persistence/missingUserFolderInterceptor.js
+++ b/src/persistence/missingUserFolderInterceptor.js
@@ -11,7 +11,7 @@ export default function missingUserFolderInterceptor(openmct, usersNamespace) {
             return !domainObject && userKeyCheck.test(identifier.namespace);
         },
         invoke: (identifier, object) => {
-            const userId = identifier.namespace.match(pattern)[1];
+            const userId = identifier.namespace.match(userKeyCheck)[1];
             const userNamespaceDefinition = interpolateUsername(usersNamespace.childTemplate, userId);
             userNamespaceDefinition.location = userNamespaceDefinition.id;
             const model = createModelFromNamespaceDefinition(userId, userNamespaceDefinition);

--- a/src/persistence/missingUserFolderInterceptor.js
+++ b/src/persistence/missingUserFolderInterceptor.js
@@ -6,8 +6,6 @@ export default function missingUserFolderInterceptor(openmct, usersNamespace) {
 
     openmct.objects.addGetInterceptor({
         appliesTo: (identifier, domainObject) => {
-            console.log('usersNamespace', usersNamespace);
-            console.log(identifier, !domainObject && userKeyCheck.test(identifier.namespace));
             return !domainObject && userKeyCheck.test(identifier.namespace);
         },
         invoke: (identifier, object) => {

--- a/src/persistence/missingUserFolderInterceptor.js
+++ b/src/persistence/missingUserFolderInterceptor.js
@@ -10,9 +10,13 @@ export default function missingUserFolderInterceptor(openmct, usersNamespace) {
         },
         invoke: (identifier, object) => {
             const userId = identifier.key.match(pattern)[1];
-            const model = createModelFromNamespaceDefinition(userId, namespaceDefinition);
+            const userNamespaceDefinition = interpolateUsername(usersNamespace.childTemplate, userId);
+            userNamespaceDefinition.location = userNamespaceDefinition.id;
+            const model = createModelFromNamespaceDefinition(userId, userNamespaceDefinition);
             
-            return object;
+            openmct.objects.save(model);
+            
+            return model;
         }
     });
 }

--- a/src/persistence/missingUserFolderInterceptor.js
+++ b/src/persistence/missingUserFolderInterceptor.js
@@ -1,4 +1,7 @@
-import { createModelFromNamespaceDefinition, interpolateUsername } from './utils';
+import {
+  createModelFromNamespaceDefinition,
+  interpolateUsername
+} from './utils';
 
 export default function missingUserFolderInterceptor(openmct, usersNamespace) {
     const userTemplate = usersNamespace.childTemplate.key.split('$')[0];

--- a/src/persistence/plugin.js
+++ b/src/persistence/plugin.js
@@ -11,9 +11,9 @@ export default function MCWSPersistenceProviderPlugin(configNamespaces) {
         });
         openmct.objects.addRoot(() => rootsPromise);
         const namespaces = configNamespaces.map(createNamespace);
+        const usersNamespace = structuredClone(namespaces.find((namespace) => namespace.containsNamespaces));
         const mcwsPersistenceProvider = new MCWSPersistenceProvider(openmct, namespaces);
 
-        const usersNamespace = structuredClone(namespaces.find((namespace) => namespace.containsNamespaces));
         const checkOldNamespaces = localStorage.getItem(`r5.0_old_namespace_checked:${usersNamespace.key}`) === null;
         existingNamespaceUpdateInterceptor(openmct, usersNamespace, checkOldNamespaces);
         missingUserFolderInterceptor(openmct, usersNamespace);

--- a/src/persistence/plugin.js
+++ b/src/persistence/plugin.js
@@ -1,6 +1,7 @@
 import { createIdentifierFromNamespaceDefinition, createNamespace } from './utils';
 import existingNamespaceUpdateInterceptor from './existingNamespaceUpdateInterceptor';
 import MCWSPersistenceProvider from './MCWSPersistenceProvider';
+import missingUserFolderInterceptor from './missingUserFolderInterceptor';
 
 export default function MCWSPersistenceProviderPlugin(configNamespaces) {
     return async function install(openmct) {
@@ -15,6 +16,7 @@ export default function MCWSPersistenceProviderPlugin(configNamespaces) {
         const usersNamespace = namespaces.find((namespace) => namespace.containsNamespaces);
         const checkOldNamespaces = localStorage.getItem(`r5.0_old_namespace_checked:${usersNamespace.key}`) === null;
         existingNamespaceUpdateInterceptor(openmct, usersNamespace, checkOldNamespaces);
+        missingUserFolderInterceptor(openmct, usersNamespace);
 
         // install the provider for each persistence space,
         // key is the namespace in the response for persistence namespaces

--- a/src/persistence/plugin.js
+++ b/src/persistence/plugin.js
@@ -13,7 +13,7 @@ export default function MCWSPersistenceProviderPlugin(configNamespaces) {
         const namespaces = configNamespaces.map(createNamespace);
         const mcwsPersistenceProvider = new MCWSPersistenceProvider(openmct, namespaces);
 
-        const usersNamespace = namespaces.find((namespace) => namespace.containsNamespaces);
+        const usersNamespace = structuredClone(namespaces.find((namespace) => namespace.containsNamespaces));
         const checkOldNamespaces = localStorage.getItem(`r5.0_old_namespace_checked:${usersNamespace.key}`) === null;
         existingNamespaceUpdateInterceptor(openmct, usersNamespace, checkOldNamespaces);
         missingUserFolderInterceptor(openmct, usersNamespace);

--- a/src/persistence/plugin.js
+++ b/src/persistence/plugin.js
@@ -11,7 +11,8 @@ export default function MCWSPersistenceProviderPlugin(configNamespaces) {
         });
         openmct.objects.addRoot(() => rootsPromise);
         const namespaces = configNamespaces.map(createNamespace);
-        const usersNamespace = structuredClone(namespaces.find((namespace) => namespace.containsNamespaces));
+        let usersNamespace = namespaces.find((namespace) => namespace.containsNamespaces);
+        usersNamespace = structuredClone(usersNamespace);
         const mcwsPersistenceProvider = new MCWSPersistenceProvider(openmct, namespaces);
 
         const checkOldNamespaces = localStorage.getItem(`r5.0_old_namespace_checked:${usersNamespace.key}`) === null;

--- a/src/persistence/utils.js
+++ b/src/persistence/utils.js
@@ -19,8 +19,8 @@ export function createModelFromNamespaceDefinition(userId, namespaceDefinition, 
     return model;
 }
 
-export function createModelFromNamespaceDefinitionWithPersisted() {
-    const model = createModelFromNamespaceDefinition(...arguments);
+export function createModelFromNamespaceDefinitionWithPersisted(userId, namespaceDefinition, composition = []) {
+    const model = createModelFromNamespaceDefinition(userId, namespaceDefinition, composition = []);
 
     model.persisted = Date.now();
 

--- a/src/persistence/utils.js
+++ b/src/persistence/utils.js
@@ -44,3 +44,22 @@ export function createNamespace(namespace) {
         };
     }
 }
+
+/**
+ * Interpolate a username with all values in a supplied object, replacing
+ * '${USER}' with the supplied username.
+ *
+ * @private
+ * @param {NamespaceTemplate} templateObject namespace template object.
+ * @param {string} username a username.
+ * @returns {NamespaceDefinition} a namespace definition object.
+ */
+export function interpolateUsername(templateObject, username) {
+    const namespaceDefinition = {};
+
+    Object.keys(templateObject).forEach(key => {
+        namespaceDefinition[key] = templateObject[key].replace('${USER}', username);
+    });
+    
+    return namespaceDefinition;
+}

--- a/src/persistence/utils.js
+++ b/src/persistence/utils.js
@@ -5,7 +5,7 @@ export function createIdentifierFromNamespaceDefinition(namespaceDefinition) {
     };
 }
 
-export function createModelFromNamespaceDefinition(userId, namespaceDefinition, composition = []) {
+export function createModelFromNamespaceDefinition(userId, namespaceDefinition, composition = [], persistenceTime) {
     const model = {
         identifier: createIdentifierFromNamespaceDefinition(namespaceDefinition),
         name: namespaceDefinition.name,
@@ -15,6 +15,18 @@ export function createModelFromNamespaceDefinition(userId, namespaceDefinition, 
         composition,
         location: namespaceDefinition.location || 'ROOT'
     };
+
+    if (persistenceTime) {
+        model.persisted = Date.now();
+    }
+
+    return model;
+}
+
+export function createModelFromNamespaceDefinitionWithPersisted(userId, namespaceDefinition, composition = []) {
+    const model = createModelFromNamespaceDefinition(...arguments);
+
+    model.persisted = Date.now();
 
     return model;
 }

--- a/src/persistence/utils.js
+++ b/src/persistence/utils.js
@@ -5,7 +5,7 @@ export function createIdentifierFromNamespaceDefinition(namespaceDefinition) {
     };
 }
 
-export function createModelFromNamespaceDefinition(userId, namespaceDefinition, composition = [], persistenceTime) {
+export function createModelFromNamespaceDefinition(userId, namespaceDefinition, composition = []) {
     const model = {
         identifier: createIdentifierFromNamespaceDefinition(namespaceDefinition),
         name: namespaceDefinition.name,

--- a/src/persistence/utils.js
+++ b/src/persistence/utils.js
@@ -16,14 +16,10 @@ export function createModelFromNamespaceDefinition(userId, namespaceDefinition, 
         location: namespaceDefinition.location || 'ROOT'
     };
 
-    if (persistenceTime) {
-        model.persisted = Date.now();
-    }
-
     return model;
 }
 
-export function createModelFromNamespaceDefinitionWithPersisted(userId, namespaceDefinition, composition = []) {
+export function createModelFromNamespaceDefinitionWithPersisted() {
     const model = createModelFromNamespaceDefinition(...arguments);
 
     model.persisted = Date.now();

--- a/src/persistence/utils.js
+++ b/src/persistence/utils.js
@@ -11,7 +11,6 @@ export function createModelFromNamespaceDefinition(userId, namespaceDefinition, 
         name: namespaceDefinition.name,
         createdBy: userId,
         created: Date.now(),
-        persisted: Date.now(),
         type: 'folder',
         composition,
         location: namespaceDefinition.location || 'ROOT'


### PR DESCRIPTION
closes #68 

Pre 5.0, OMM would create user folders without a root object inside. Once we upgraded out of legacy persistence, these objects are created when the user folder is created. In older persistence, it would not know to create the new roots in an empty folder, this fix addresses this. It will be run once per user folder and will never run again after the folder root is created, due to a flag in localStorage. Deleting this flag, will cause the checks to run again (once).