### PR TITLE
[Global Filters] Handle errors when endpoints don't support a filter

### DIFF
--- a/src/historical/HistoricalProvider.js
+++ b/src/historical/HistoricalProvider.js
@@ -569,7 +569,14 @@ define([
         if (provider.batchId) {
             return this.doQueuedRequest(domainObject, options, params, provider);
         }
-        return provider.request(domainObject, options, params);
+        return provider.request(domainObject, options, params)
+            .catch((errorResponse) => {
+                if (errorResponse.status === 400 && filterService.hasActiveFilters()) {
+                    this.openmct.notifications.alert(`Issue processing request for ${domainObject.name}. If using global filters, please adjust or remove them and try again.`);
+                } else {
+                    throw errorResponse;
+                }
+            });
     };
 
     HistoricalProvider.prototype.removeFiltersIfAllSelected = function(domainObject, filters) {

--- a/src/historical/HistoricalProvider.js
+++ b/src/historical/HistoricalProvider.js
@@ -579,7 +579,7 @@ define([
                 const match = responseBody.match(/does not contain the specified parameter column: (\w+)/);
 
                 if (match && filterService.hasActiveFilters()) {
-                    this.openmct.notifications.alert(`Error with ${domainObject.name}: Unsupported filter "${match[1]}". If set, please remove the global filter and retry.`);
+                    this.openmct.notifications.error(`Error requesting telemetry data for ${domainObject.name}: Unsupported filter "${match[1]}". If set, please remove the global filter and retry.`);
                 } else {
                     throw errorResponse;
                 }

--- a/src/historical/HistoricalProvider.js
+++ b/src/historical/HistoricalProvider.js
@@ -575,7 +575,7 @@ define([
         }
         return provider.request(domainObject, options, params)
             .catch(async (errorResponse) => {
-                const responseBody = await response.text();
+                const responseBody = await errorResponse.text();
                 const match = responseBody.match(/does not contain the specified parameter column: (\w+)/);
 
                 if (match && filterService.hasActiveFilters()) {


### PR DESCRIPTION
There are some endpoints that will not support all filters that are set globally. This update will allow the user to see what the error is and unset the filters if they desire.

This will only notify the user when global filters are set and the following type of response (400) is received from MCWS:
![Screenshot 2023-09-13 at 4 11 21 PM](https://github.com/NASA-AMMOS/openmct-mcws/assets/12013460/a7038a04-56d8-4b1e-9c24-163c06f14243)

It will pull the filter that is an issue and include it in the notification.