### PR TITLE
Remove unnecessary `innerHTML` in code

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "5.2.0-rc1",
   "description": "Open MCT for MCWS",
   "devDependencies": {
+    "@braintree/sanitize-url": "6.0.2",
     "axios": "^0.21.2",
     "babel-loader": "8.2.3",
     "babel-plugin-istanbul": "6.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmct-mcws",
-  "version": "5.2.0-rc1",
+  "version": "5.2.0-rc2",
   "description": "Open MCT for MCWS",
   "devDependencies": {
     "@braintree/sanitize-url": "6.0.2",
@@ -32,7 +32,7 @@
     "mini-css-extract-plugin": "2.6.0",
     "moment": "2.29.4",
     "node-bourbon": "^4.2.3",
-    "openmct": "nasa/openmct#omm-r5.2.0-rc1",
+    "openmct": "nasa/openmct#omm-r5.2.0-rc2",
     "openmct-legacy-support": "akhenry/openmct-legacy-support#omm-r5.1.0-rc1",
     "printj": "^1.2.1",
     "raw-loader": "^0.5.1",

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>gov.nasa.arc.wtd</groupId>
     <artifactId>openmct-client</artifactId>
     <name>Open MCT for MCWS Client</name>
-    <version>5.2.0-rc1</version>
+    <version>5.2.0-rc2</version>
     <packaging>war</packaging>
 
     <properties>

--- a/src/identity/LoginService.js
+++ b/src/identity/LoginService.js
@@ -1,9 +1,7 @@
 /*global define*/
 define(
-    [
-        './login.html'
-    ],
-    function (loginTemplate) {
+    [],
+    function () {
 
 
         /**

--- a/src/identity/LoginService.js
+++ b/src/identity/LoginService.js
@@ -48,9 +48,13 @@ define(
         LoginService.prototype.show = function () {
             this.overlay = document.createElement('div');
             this.overlay.classList.add('u-contents');
-            this.overlay.innerHTML = loginTemplate;
+            
+            const iframe = document.createElement('iframe');
+            iframe.classList.add('c-login-overlay');
+            iframe.src = this.getLoginUrl();
+
+            this.overlay.appendChild(iframe);
             document.body.appendChild(this.overlay);
-            this.overlay.querySelector('iframe').src = this.getLoginUrl();
         };
 
         /**

--- a/src/identity/login.html
+++ b/src/identity/login.html
@@ -1,1 +1,0 @@
-<iframe class="c-login-overlay"></iframe>

--- a/src/link/plugin.js
+++ b/src/link/plugin.js
@@ -1,7 +1,7 @@
 define([
-
+    '@braintree/sanitize-url'
 ], function (
-
+    urlSanitizeLib
 ) {
 
     function LinkPlugin() {
@@ -32,7 +32,13 @@ define([
                 view: function (domainObject) {
                     return {
                         show: function (container) {
-                            container.innerHTML = '<a href="' + domainObject.url + '">' + domainObject.name + '</a>'
+                            container.textContent = '';
+
+                            const anchor = document.createElement('a');
+                            anchor.href = urlSanitizeLib.sanitizeUrl(domainObject.url);
+                            anchor.textContent = domainObject.name;
+
+                            container.appendChild(anchor);
                         },
                         destroy: function () {}
                     };


### PR DESCRIPTION
- added a url sanitizer library for links
- using it in links to sanitize user provided url
- switched to innerText for link as well
- removed an unproblematic use of innerHTML in loginService code and optimized it (loginService _may_ not be used anymore)