### PR TITLE
Update issue templates for clarity and reporting purposes

### DIFF
--- a/.github/ISSUE_TEMPLATE/commitment.md
+++ b/.github/ISSUE_TEMPLATE/commitment.md
@@ -1,10 +1,46 @@
 ---
 name: Commitment
-about: MGSS commitment
+about: Items in this category are considered significant to the functionality of the software, the workload of the subsystem or a promised commitment to customers or the MGSS Program Office
 title: ''
 labels: commitment
 assignees: ''
 
 ---
 
+<!--
+Because of their significance, items in this category require a rationale for why the task is doing them. Valid rationales would include:
 
+- The initial implementation of approved requirements
+- The implementation of an approved change request
+- The implementation of an action item approved by the Program Office
+- A work agreement that includes deliverables or a specific description of the work in the RLI (a general overview or level of effort is not sufficient).
+-->
+
+**Describe the commitment**
+<!-- A clear and concise description of what the commitment is. -->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expect to happen. -->
+
+**Testing Instructions**
+1. 
+
+**Additional context**
+<!-- Add any other context or screenshots about the commitment here. -->
+
+<!-- REPORT SECTION
+Fill in any of the below values that apply, they can then be pulled out for reporting purposes. Add the information directly after the ":" on one line.
+
+Who reported this?
+$$reporter:
+
+Is there an ask ticket number (ex. 322)?
+$$ask:
+
+Time estimate (ex. 3 days or 8 hours)
+$$estimate:
+
+Is there a rationale?
+$$rationale:
+
+END REPORT SECTION -->

--- a/.github/ISSUE_TEMPLATE/defect-report.md
+++ b/.github/ISSUE_TEMPLATE/defect-report.md
@@ -1,11 +1,16 @@
 ---
 name: Defect Report
 about: Report a defect and report a criticality
-title: "[DEFECT] "
+title: ""
 labels: defect
 assignees: ''
 
 ---
+
+<!-- 
+Bugs discovered during testing of the release.
+Bugs related to fixing items found in security scans.
+-->
 
 **Describe the defect**
 <!-- A clear and concise description of what the bug is. -->
@@ -15,20 +20,33 @@ assignees: ''
 
 **Steps To Reproduce**
 1. 
-2. 
-3. 
-4. 
 
-**Environment (please complete the following information):**
- - Version [<!-- e.g. release version, commit hash, branch-->]
- - Browser [<!-- e.g. chrome, safari -->]
 
 **Additional context**
-Add any other context, code snippets, error messages, screen shots about the problem here.
+<!-- Add any other context, software version, browser, code snippets, error messages, screen shots about the problem here. -->
 
-|Criticality|Name|Description|
-|---|---|---|
-|crit1|Critical|Defect makes the software unusable for mission operations.|
-|crit2|Major|Defect has significant impact on usability of delivered software for mission operations. User experience is difficult and/or cumbersome. Workaround available is arduous.|
-|crit3|Moderate|Defect has moderate to mild impact on usability of delivered software for mission operations. User experience is degraded but workable.|
-|crit4|Minor|Defect means software does not work as originally intended, but the defect has little impact on the usability of the delivered software.|
+
+<!--
+Consider adding a criticality label.
+
+Criticality Label Descriptions
+crit1 - Critical: Defect makes the software unusable for mission operations.
+crit2 - Major: Defect has significant impact on usability of delivered software for mission operations. User experience is difficult and/or cumbersome. Workaround available is arduous.
+crit3 - Moderate: Defect has moderate to mild impact on usability of delivered software for mission operations. User experience is degraded but workable.
+crit4 - Minor: Defect means software does not work as originally intended, but the defect has little impact on the usability of the delivered software.
+-->
+
+
+<!-- REPORT SECTION
+Fill in any of the below values that apply, they can then be pulled out for reporting purposes. Add the information directly after the ":" on one line.
+
+Who reported this?
+$$reporter:
+
+Is there an ask ticket number (ex. 322)?
+$$ask:
+
+Time estimate (ex. 3 days or 8 hours)
+$$estimate:
+
+END REPORT SECTION -->

--- a/.github/ISSUE_TEMPLATE/improvement.md
+++ b/.github/ISSUE_TEMPLATE/improvement.md
@@ -1,26 +1,39 @@
 ---
 name: Improvement
-about: Improvements are enhancements to already implemented requirements that does
-  not change the requirement or previously documented interfaces.
+about: Improvements are enhancements to already implemented requirements that does not change the requirement or previously documented interfaces.
 title: ''
 labels: improvement
 assignees: ''
 
 ---
 
+<!--
+An improvement is a modification to an existing capability. Improvements are enhancements to already implemented requirements and the improvement does not change the requirement or previously documented interfaces. Improvements are expected to be relatively low-cost, requiring roughly a work-week or less for implementation. Typically, improvements focus on enhancing usability or performance of the software.
+-->
+
 **Is your feature request related to a problem? Please describe.**
 <!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
 **Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+<!-- A clear and concise description of what you want to happen. -->
 
 **Testing Instructions**
 1. 
-2. 
-3. 
-4. 
-
-An improvement is a modification to an existing capability. Improvements are enhancements to already implemented requirements and the improvement does not change the requirement or previously documented interfaces. Improvements are expected to be relatively low-cost, requiring roughly a work-week or less for implementation. Typically, improvements focus on enhancing usability or performance of the software.
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+<!-- Add any other context or screenshots about the feature request here. -->
+
+
+<!-- REPORT SECTION
+Fill in any of the below values that apply, they can then be pulled out for reporting purposes. Add the information directly after the ":" on one line.
+
+Who reported this?
+$$reporter:
+
+Is there an ask ticket number (ex. 322)?
+$$ask:
+
+Time estimate (ex. 3 days or 8 hours)
+$$estimate:
+
+END REPORT SECTION -->

--- a/.github/ISSUE_TEMPLATE/other.md
+++ b/.github/ISSUE_TEMPLATE/other.md
@@ -1,14 +1,14 @@
 ---
-name: Documentation
-about: A modification to the project's released documentation.
+name: Other
+about: Any items that are not one of the following (Commitment, Imporovement, Defect Report, Sustaining Activity, Document)
 title: ''
-labels: documentation
+labels: other
 assignees: ''
 
 ---
 
-**Describe the document**
-<!-- A clear and concise description of what the document is. -->
+**Description**
+<!-- A clear and concise description of what the item is. -->
 
 **Additional context**
 <!-- Add any other context or information here. -->
@@ -16,9 +16,6 @@ assignees: ''
 
 <!-- REPORT SECTION
 Fill in any of the below values that apply, they can then be pulled out for reporting purposes. Add the information directly after the ":" on one line.
-
-Enter the document id for this item (ex. DOC-44322)
-$$docid:
 
 Time estimate (ex. 3 days or 8 hours)
 $$estimate:

--- a/.github/ISSUE_TEMPLATE/sustaining-activities.md
+++ b/.github/ISSUE_TEMPLATE/sustaining-activities.md
@@ -1,11 +1,39 @@
 ---
 name: Sustaining Activities
-about: Covers work to maintain current capabilities in a changing environment. Operation
-  of the software or documented software interfaces is unchanged.
+about: Covers work to maintain current capabilities in a changing environment. Operation of the software or documented software interfaces is unchanged.
 title: ''
 labels: sustaining
 assignees: ''
 
 ---
 
+<!--
+If sustaining activities are mandated by an approved Change Request or Action Item from the MGSS Program Office they fall under the Commitments category.
+-->
 
+**Describe the sustaining activity**
+<!-- A clear and concise description of what the sustaining activity is. -->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Testing Instructions**
+1. 
+
+**Additional context**
+<!-- Add any other context or screenshots about the sustaining activity here. -->
+
+
+<!-- REPORT SECTION
+Fill in any of the below values that apply, they can then be pulled out for reporting purposes. Add the information directly after the ":" on one line.
+
+Is there a rationale?
+$$rationale:
+
+Who requested this?
+$$requester:
+
+Time estimate (ex. 3 days or 8 hours)
+$$estimate:
+
+END REPORT SECTION -->


### PR DESCRIPTION
Removed some items (steps 2 - 4, seem unnecessary), criticality table (replaced with a comment of descriptions for labels), environment block (moved to "Additional Context" section). Added a reporting section in a comment, this can be scanned to pull in important information for reporting releases (note unique to each type). Added "Other" template to match reporting requirements. Pulled in additional information from reporting documents as well for more information purposes (usually in comments in the issue).