### PR TITLE
[Sessions] Don't send Proxy Objects in a worker message

### DIFF
--- a/src/realtimeSessions/components/RealtimeSessionSelector.vue
+++ b/src/realtimeSessions/components/RealtimeSessionSelector.vue
@@ -104,6 +104,7 @@
 </template>
 
 <script>
+import { toRaw } from 'vue';
 import SessionService from 'services/session/SessionService';
 
 export default {
@@ -135,7 +136,8 @@ export default {
             this.selection = model;
         },
         setActiveTopicOrSession() {
-            this.sessionService.setActiveTopicOrSession(this.selection.data);
+            const plainData = toRaw(this.selection.data);
+            this.sessionService.setActiveTopicOrSession(plainData);
 
             this.closeOverlay();
         },

--- a/src/venues/components/VenueDialogComponent.vue
+++ b/src/venues/components/VenueDialogComponent.vue
@@ -83,6 +83,7 @@
 import ActiveVenueSelectorComponent from './ActiveVenueSelectorComponent.vue';
 import ActiveSessionSelectorComponent from './ActiveSessionSelectorComponent.vue';
 import HistoricalSessionSelectorComponent from './HistoricalSessionSelectorComponent.vue';
+import { toRaw } from 'vue';
 
 export default {
   components: {
@@ -131,7 +132,7 @@ export default {
       this.selectedSession = session;
     },
     submit() {
-      this.$emit('submit', this.isActiveVenueSelect, this.selectedSession, this.selectedVenue);
+      this.$emit('submit', this.isActiveVenueSelect, toRaw(this.selectedSession), this.selectedVenue);
     },
     async fetchAndSetUrlsForHistoricalSessions() {
       try {


### PR DESCRIPTION
Vue reactivity was leaking into an object sent as a message, which was erroring out as it's passed through Structured Clone. This fix will call `toRaw` on the objects before passing them through. This was only on the initial connection message, but it required a refresh for RealTime sessions to work.