### PR TITLE
Realtime Config flag fix

### DIFF
--- a/config.js
+++ b/config.js
@@ -281,11 +281,13 @@
             /**
              * allowRealtime: whether or not to allow utc-relative time conductor.
              */
-            allowRealtime: true,
+            allowRealtime: false,
             /**
-             * allowLAD: whether or not to allow latest data relative time conductor.
+             * allowLAD: whether or not to allow latest data relative time conductor. 
+             * 
+             * Note: allowRealtime must be true to use this option
              */
-            allowLAD: true,
+            allowLAD: false,
             /**
              * records: number of previous bounds per timeSystem to save in time conductor history.
              */

--- a/config.js
+++ b/config.js
@@ -281,13 +281,13 @@
             /**
              * allowRealtime: whether or not to allow utc-relative time conductor.
              */
-            allowRealtime: false,
+            allowRealtime: true,
             /**
              * allowLAD: whether or not to allow latest data relative time conductor. 
              * 
              * Note: allowRealtime must be true to use this option
              */
-            allowLAD: false,
+            allowLAD: true,
             /**
              * records: number of previous bounds per timeSystem to save in time conductor history.
              */

--- a/src/time/plugin.js
+++ b/src/time/plugin.js
@@ -104,7 +104,7 @@ export default function TimePlugin(options) {
                 }
             });
         }
-        if (options.allowLAD) {
+        if (options.allowRealtime && options.allowLAD) {
             var ladClock = new LADClock(key);
             install.ladClocks[key] = ladClock;
             openmct.time.addClock(ladClock);


### PR DESCRIPTION
With recent changes to the time conductor in core, Realtime was always showing even when no clocks were registered. This fixes that.