### PR TITLE
Temporarily remove LMST and SCLK from default time systems in configuration

### DIFF
--- a/config.js
+++ b/config.js
@@ -189,9 +189,7 @@
              */
             timeSystems: [
                 'scet',
-                'ert',
-                'sclk',
-                'lmst'
+                'ert'
             ],
 
             /**


### PR DESCRIPTION
Due to updates in core Open MCT in the Time Conductor, these two time systems are currently breaking. Until there is a fix we're removing them from the default config.