### PR TITLE
Fix timesystem config

### DIFF
--- a/config.js
+++ b/config.js
@@ -200,84 +200,110 @@
              *
              * key property is required and other options are optional
              * timeSystem:
-             * * key: string, required
+             * * key: string, required. Time system. Options are 'scet', 'ert', 'sclk', 'msl.sol' and 'lmst'.
              * * limit: number, optional - maximum duration between start and end bounds allow
-             * * presets: array, optional - preset bounds for convenience
-             * * * preset:
-             * * * * label: string, descriptive label for preset
+             * * modeSettings: object, optional - presets for convenience. 
+             * * * fixed: object, optional - valid objects are bounds objects and presets array. 
+             * * * realtime: object, optional - valid objects are clockOffsets and presets array. 
+             * * * lad:object, optional - valid objects are clockoffsets. 
+             * * * * 
+             * * * * Optional objects: 
              * * * * bounds: start and end bounds for preset as numbers
-             * * * * * * * * start and end can be declared as a number or a function returning a number
-             * 
+             * * * * * * * * start: and end: can be declared as a number or a function returning a number
+             * * * * presets: array of objects consisting of: 
+             * * * * * bounds: - required. 
+             * * * * * label: - required, string
+             * * * * clockOffsets: object, optional. Start and end relative to active clock. 
+             * * * * start: and end: numbers relative to active clock's 0. Start is negative, end is positive. 
              * *advanced** example configuration below 
-             *
+             
             timeSystems: [
-                {
-                    key:'scet',
-                    presets: [
-                        {
-                            label: 'Last 2 hours',
-                            bounds: {
-                                start: Date.now() - 1000 * 60 * 60 * 2,
-                                end: Date.now()
-                            }
-                        },
-                        {
-                            label: 'Last 1 hour',
-                            bounds: {
-                                start: Date.now() - 1000 * 60 * 60,
-                                end: Date.now()
-                            }
+             {
+                key:'scet',
+                modeSettings:{
+                  fixed:{
+                    bounds:{
+                            start: new Date(Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth(), new Date().getUTCDate() - 2)).setUTCHours(0, 0, 0, 0),
+                            end: new Date(Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth(), new Date().getUTCDate())).setUTCHours(23,59, 59, 999)                       
+                            },
+                    presets:[
+                      {
+                        label: 'Last 2 hours (SCET Recorded)',
+                        bounds: {
+                            start: Date.now() - 1000 * 60 * 60 * 2,
+                            end: Date.now()
                         }
-                    ],
-                    limit: 1000 * 60 * 60 * 6
-                },
-                {
-                    key:'ert',
-                    presets: [
-                        {
-                            label: 'Last 2 hours',
-                            bounds: {
-                                start: Date.now() - 1000 * 60 * 60 * 2,
-                                end: Date.now()
-                            }
-                        },
-                        {
-                            label: 'Last 1 hour',
-                            bounds: {
-                                start: Date.now() - 1000 * 60 * 60,
-                                end: Date.now()
-                            }
+                      },
+                    ]
+                  },
+                  realtime:{
+                    clockOffsets:{
+                      start: -60 * 60 * 1000,
+                      end: 5 * 60 * 1000
+                    },
+                    presets:[
+                      {
+                        label: 'Last 2 hours (SCET Realtime)',
+                        bounds: {
+                            start: -60 * 60 * 1000,
+                            end: 5 * 60 * 1000
                         }
-                    ],
-                    limit: 1000 * 60 * 60 * 6
+                      }
+                    ]
+                  },
+                  lad:{
+                    clockOffsets:{
+                      start: -60 * 60 * 1000,
+                      end: 5 * 60 * 1000
+                    },
+                  },
+              },
+                limit: 1000 * 60 * 60 * 60
+            },
+            {
+              key:'ert',
+              modeSettings:{
+                fixed:{
+                  bounds:{
+                          start: new Date(Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth(), new Date().getUTCDate() - 4)).setUTCHours(0, 0, 0, 0),
+                          end: new Date(Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth(), new Date().getUTCDate())).setUTCHours(23,59, 59, 999)                       
+                          },
+                  presets:[
+                    {
+                      label: 'Last 2 hours (ERT Recorded)',
+                      bounds: {
+                          start: Date.now() - 1000 * 60 * 60 * 2,
+                          end: Date.now()
+                      }
+                    },
+                  ]
                 },
-                {
-                    key:'sclk',
-                    presets: [
-                        {
-                            label: 'Last 2 hours',
-                            bounds: {
-                                start: Date.now() - 1000 * 60 * 60 * 2,
-                                end: Date.now()
-                            }
-                        },
-                        {
-                            label: 'Last 1 hour',
-                            bounds: {
-                                start: Date.now() - 1000 * 60 * 60,
-                                end: Date.now()
-                            }
-                        }
-                    ],
-                    limit: 1000 / 5 * 60 * 60 * 6
+                realtime:{
+                  clockOffsets:{
+                    start: -60 * 60 * 1000,
+                    end: 5 * 60 * 1000
+                  },
+                  presets:[
+                    {
+                      label: 'Last 2 hours (ERT Realtime)',
+                      bounds: {
+                          start: -60 * 60 * 1000,
+                          end: 5 * 60 * 1000
+                      }
+                    }
+                  ]
                 },
-                {
-                    key:'lmst',
-                    presets: []
-                }
-            ],
+                lad:{
+                  clockOffsets:{
+                    start: -60 * 60 * 1000,
+                    end: 5 * 60 * 1000
+                  },
+                },
+            },
+              limit: 1000 * 60 * 60 * 60
+           }
+          ],
             */
-
             /**
              * allowRealtime: whether or not to allow utc-relative time conductor.
              */

--- a/config.js
+++ b/config.js
@@ -4,12 +4,12 @@
          * camUrl: url to the CAM server this instance uses for auth.
          * ***** REQUIRED *****
          */
-        camUrl: '',
+        camUrl: 'https://sso.vitals.jpl.nasa.gov/login.html?req=mct.vitals.jpl.nasa.gov&login_uri=/&login_querystring=',
         /**
          * mcwsUrl: url for MCWS root.
          * ***** REQUIRED *****
          */
-        mcwsUrl: '',
+        mcwsUrl: 'https://mct.vitals.jpl.nasa.gov/mcws',
         /**
          * theme: either 'Snow', 'Espresso' or 'Maelstrom'
          */
@@ -29,17 +29,22 @@
          * ***** URL REQUIRED *****
          */
         namespaces: [
-            {
-                key: 'r50-dev',
-                name: 'R5.0 Shared',
-                url: ''
-            },
-            {
-                userNamespace: true,
-                key: 'r50-dev',
-                name: 'R5.0 Users',
-                url: ''
-            }
+          {
+             key: 'shared',
+             name: 'Shared',
+             url: 'https://mct.vitals.jpl.nasa.gov/mcws/fastmio/ops/shared'
+          }, 
+          {
+             key: 'systems',
+             name: 'Systems',
+             url: 'https://mct.vitals.jpl.nasa.gov/mcws/fastmio/ops/systems'
+          },
+          {
+             key: 'users',
+             name: 'Users',
+             userNamespace: true,
+             url: 'https://mct.vitals.jpl.nasa.gov/mcws/fastmio/ops/users'
+          },
         ],
 
         /**
@@ -186,14 +191,11 @@
             /**
              * timeSystems: specify the time systems to use.
              * Options are 'scet', 'ert', 'sclk', 'msl.sol' and 'lmst'.
-             */
+             
             timeSystems: [
-                'scet',
-                'ert',
-                'sclk',
-                'lmst'
+                'scet'
             ],
-
+            */
             /**
              * timeSystems advanced configuration: 
              * Replace the above basic configuration with timeSystem specific configurations
@@ -216,104 +218,60 @@
              * * * * clockOffsets: object, optional. Start and end relative to active clock. 
              * * * * start: and end: numbers relative to active clock's 0. Start is negative, end is positive. 
              * *advanced** example configuration below 
-             
+             */
             timeSystems: [
-             {
-                key:'scet',
-                modeSettings:{
-                  fixed:{
-                    bounds:{
-                            start: new Date(Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth(), new Date().getUTCDate() - 2)).setUTCHours(0, 0, 0, 0),
-                            end: new Date(Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth(), new Date().getUTCDate())).setUTCHours(23,59, 59, 999)                       
-                            },
-                    presets:[
-                      {
-                        label: 'Last 2 hours (SCET Recorded)',
-                        bounds: {
-                            start: Date.now() - 1000 * 60 * 60 * 2,
-                            end: Date.now()
-                        }
+              {
+                  key:'scet',
+                  modeSettings:{
+                    fixed:{
+                      bounds:{
+                              start: new Date(Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth(), new Date().getUTCDate() - 1)).setUTCHours(0, 0, 0, 0),
+                              end: new Date(Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth(), new Date().getUTCDate())).setUTCHours(23,59, 59, 999)                       
+                             },
+                      presets:[
+                        {
+                          label: 'Last 2 hours (SCET Recorded)',
+                          bounds: {
+                              start: Date.now() - 1000 * 60 * 60 * 2,
+                              end: Date.now()
+                          }
+                        },
+                      ]
+                    },
+                    realtime:{
+                      clockOffsets:{
+                        start: -60 * 60 * 1000,
+                        end: 5 * 60 * 1000
                       },
-                    ]
-                  },
-                  realtime:{
-                    clockOffsets:{
-                      start: -60 * 60 * 1000,
-                      end: 5 * 60 * 1000
-                    },
-                    presets:[
-                      {
-                        label: 'Last 2 hours (SCET Realtime)',
-                        bounds: {
-                            start: -60 * 60 * 1000,
-                            end: 5 * 60 * 1000
+                      presets:[
+                        {
+                          label: 'Last 2 hours (SCET Realtime)',
+                          bounds: {
+                              start: -60 * 60 * 1000,
+                              end: 5 * 60 * 1000
+                          }
                         }
-                      }
-                    ]
-                  },
-                  lad:{
-                    clockOffsets:{
-                      start: -60 * 60 * 1000,
-                      end: 5 * 60 * 1000
+                      ]
                     },
-                  },
+                    lad:{
+                      clockOffsets:{
+                        start: -60 * 60 * 1000,
+                        end: 5 * 60 * 1000
+                      },
+                    },
+                },
+                  limit: 1000 * 60 * 60 * 60
               },
-                limit: 1000 * 60 * 60 * 60
-            },
-            {
-              key:'ert',
-              modeSettings:{
-                fixed:{
-                  bounds:{
-                          start: new Date(Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth(), new Date().getUTCDate() - 4)).setUTCHours(0, 0, 0, 0),
-                          end: new Date(Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth(), new Date().getUTCDate())).setUTCHours(23,59, 59, 999)                       
-                          },
-                  presets:[
-                    {
-                      label: 'Last 2 hours (ERT Recorded)',
-                      bounds: {
-                          start: Date.now() - 1000 * 60 * 60 * 2,
-                          end: Date.now()
-                      }
-                    },
-                  ]
-                },
-                realtime:{
-                  clockOffsets:{
-                    start: -60 * 60 * 1000,
-                    end: 5 * 60 * 1000
-                  },
-                  presets:[
-                    {
-                      label: 'Last 2 hours (ERT Realtime)',
-                      bounds: {
-                          start: -60 * 60 * 1000,
-                          end: 5 * 60 * 1000
-                      }
-                    }
-                  ]
-                },
-                lad:{
-                  clockOffsets:{
-                    start: -60 * 60 * 1000,
-                    end: 5 * 60 * 1000
-                  },
-                },
-            },
-              limit: 1000 * 60 * 60 * 60
-           }
-          ],
-            */
+            ],
+
             /**
              * allowRealtime: whether or not to allow utc-relative time conductor.
              */
-            allowRealtime: true,
+            allowRealtime: false,
             /**
-             * allowLAD: whether or not to allow latest data relative time conductor. 
-             * 
-             * Note: allowRealtime must be true to use this option
+             * allowLAD: whether or not to allow latest data relative time conductor.
              */
-            allowLAD: true,
+            allowLAD: false,
             /**
              * records: number of previous bounds per timeSystem to save in time conductor history.
              */
@@ -412,7 +370,7 @@
          * units - milliseconds
          * !!when set to undefined, user will not be warned and queries will not be blocked
          */
-        queryTimespanLimit: undefined,
+        queryTimespanLimit: 30*24*60*60*1000,
 
         /**
          * Time since last received realtime datum. 
@@ -454,7 +412,7 @@
          */
         sessions: {
             historicalSessionFilter: {
-                disable: false,
+                disable: true,
                 maxRecords: 100,
                 denyUnfilteredQueries: false
             },
@@ -464,72 +422,35 @@
         },
 
         /**
-         * Enable global filters for ALL telemetry requests that support the filter. 
-         * Telemetry filters modify the 'filter' field in queries to MCWS. 
+         * Enable global filters for ALL telemetry requests that support the filter
          * 
-         * key property is required and other options are optional
-         * globalFilters: array, optional - list of global filters to configure. 
-         * * key: string, required. Filter column, e.g. vcid
-         * * name: string, required. Identifier of the filter in the selection window. 
-         * * icon: 'icon-flag', string, icon. Not implemented - potentially icon for minimized filter list. 
-         * * filter: object, required. Filter object to implement 
-         * * * comparator: string, required. currently supports 'equals'
-         * * * singleSelectionThreshold: boolean, required. currently supports true only. 
-         * * * defaultLabel: string, optional. Defaults to 'None'. Label to show if filter inactive.  
-         * * * possibleValues: array, required. List of values and labels for filter. 
-         * * * * label: string, required. Label to show in filter selection dropdown. 
-         * * * * value: string, required. value to set parameter to in filtered query. 
          * How to use:
-         * The global filters will be available from the Global Filters indicator. 
-         * Enable a filter by selecting the desired filter from the dropdown and hitting update. 
-         * Outgoing requests that use the 'filter' parameter to MCWS will be modified with your filter. 
-         * example below, selecting 'A side' will ensure that the filter parameter in mcws includes: 
-         * vcid='1,2,3'. Note that poorly formatted filters may not pass MCWS API validation. 
-         *  
+         * The global filters will be available from the Global Filters indicator
         */
-        /*
+        
         globalFilters: [
           {
-            name: 'VCID',
-            key: 'vcid',
-            icon: 'icon-flag',
+            name: 'DataTypes',
+            key: 'sc_override',
+            icon: 'icon-session',
             filter: {
               comparator: 'equals',
               singleSelectionThreshold: true,
-              defaultLabel: "A & B",
+              defaultLabel:'Realtime + Recorded',    
               possibleValues: [
                 {
-                  label: 'A Side',
-                  value: '1,2,3'
+                  label: 'Recorded Only',
+                  value: 'smap'
                 },
                 {
-                  label: 'B Side',
-                  value: '4,5,6'
+                  label: 'Realtime only',
+                  value: 'smapauto'
                 }
               ]
             }
           },
-          {
-            name: 'Realtime',
-            key: 'realtime',
-            filter: {
-              comparator: 'equals',
-              singleSelectionThreshold: true,
-              defaultLabel: "REC & RLT",
-              possibleValues: [
-                {
-                  label: 'Realtime',
-                  value: true
-                },
-                {
-                  label: 'Recorded',
-                  value: false
-                }
-              ]
-            }
-          }
         ],
-        */
+        
         /**
          * Table Performance Mode Configuration
          * Can increase performance by limiting the maximum rows retained and displayed by tables
@@ -544,8 +465,74 @@
         tablePerformanceOptions: {
           telemetryMode: 'unlimited',
           persistModeChange: false,
-          rowLimit: 50
+          rowLimit: 50000
         },
+	    
+      overrideChannelColumns:[
+	    {
+              key:'sclk',
+              action:'add',
+              position:0,
+              value:{
+                      key:'sclk',
+                      name:'SCLK',
+                      format:'sclk.float64',
+                      hints:{}
+              }
+             }
+     ],
+
+     /**
+     * EVR Column Override. Allows customization of columns in EVR tables. Via three actions:
+     * 1. 'add'. Adds a new column matching 'key'. Requires 'key','name','format',and 'hint' keys.
+     * 2. 'remove'. Removes column matching key from view.
+     * 3. 'update'. Updates the specific keys in the value object. (i.e. rename a column)
+     */
+     overrideEVRColumns: [
+            {
+              key:'sclk',
+              action:'add',
+              position:0,
+              value:{
+                      key:'sclk',
+                      name:'SCLK',
+                      format:'sclk.float64',
+                      hints:{}
+              }
+            },
+            {
+              key:'record_type',
+              action:'remove'
+            },
+            {
+              key:'dss_id',
+              action:'remove'
+            },
+            {
+              key:'realtime',
+              action:'remove'
+            },
+            {
+              key:'session_host',
+              action:'remove'
+            },
+            {
+              key:'from_sse',
+              action:'remove'
+            },
+            {
+              key:'vcid',
+              action:'remove'
+            },
+            {
+              key:'lst',
+              action:'remove'
+            },
+            {
+              key:'rct',
+              action:'remove'
+            }
+         ],
         /**
          * Developer Settings-- do not modify these unless you know what
          * they do!

--- a/loader.js
+++ b/loader.js
@@ -12,7 +12,8 @@ define([
     './src/packetSummary/plugin',
     './src/containerView/plugin',
     'services/identity/MCWSIdentityProvider',
-    './src/persistence/plugin'
+    './src/persistence/plugin',
+    './src/OMMTelemetryMean/plugin'
 ], function (
     openmct,
     AMMOSPlugins,
@@ -27,7 +28,8 @@ define([
     PacketSummaryPlugin,
     ContainerViewPlugin,
     IdentityProvider,
-    MCWSPersistenceProviderPlugin
+    MCWSPersistenceProviderPlugin,
+    OMMTelemetryMeanPlugin
 ) {
 
     function loader(config) {
@@ -82,6 +84,7 @@ define([
         openmct.install(openmct.plugins.Clock(
             { useClockIndicator: false }
         ));
+        openmct.install(OMMTelemetryMeanPlugin());
 
         openmct.install(new AMMOSPlugins(config));
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "mini-css-extract-plugin": "2.7.6",
     "moment": "2.30.1",
     "node-bourbon": "^4.2.3",
-    "openmct": "nasa/openmct#omm-r5.3.0-rc3",
+    "openmct": "mudinthewater/openmct#omm_5_3_0_plot_bf_smap",
     "printj": "1.3.1",
     "raw-loader": "^0.5.1",
     "resolve-url-loader": "5.0.0",

--- a/src/OMMTelemetryMean/plugin.js
+++ b/src/OMMTelemetryMean/plugin.js
@@ -1,0 +1,92 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2023, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+define(['./src/OMMMeanTelemetryProvider'], function (OMMMeanTelemetryProvider) {
+    const DEFAULT_SAMPLES = 10;
+    // Form dropdown defaults are set by matching value, so...the default must match.
+    const DEFAULT_RANGE = {"key": "dn", "name":"DN", "hints": {"range": 1, "priority": 1}};
+    function plugin() {
+        return function install(openmct) {
+            openmct.types.addType('telemetry-mean', {
+                name: 'OMM Telemetry Mean',
+                description: 'Provides telemetry values that represent the mean of the last N values of a telemetry stream',
+                creatable: true,
+                cssClass: 'icon-telemetry',
+                initialize: function (domainObject) {
+                    domainObject.telemetryPoint= 'vista:channel:shared-shared:d2e7fe9b-ce12-439f-86af-c18667460029:S-3118';
+                    domainObject.samples = DEFAULT_SAMPLES;
+                    domainObject.rangeidx = openmct.time.getAllTimeSystems().filter(ts => ts.key !== 'utc').length;
+                    domainObject.telemetry = {};
+                    domainObject.telemetry.values =
+                        openmct.time.getAllTimeSystems().filter(ts => ts.key !== 'utc').map(function (timeSystem, index) { 
+                            var newTimeSystem={};
+                            Object.keys(timeSystem).forEach(key => newTimeSystem[key]=timeSystem[key]);
+                            newTimeSystem['hints']={
+                                    domain: index,
+                                    priority: index
+                                };
+                            return newTimeSystem;
+                        });
+                    domainObject.telemetry.values[openmct.time.getAllTimeSystems().filter(ts => ts.key !== 'utc').length]=DEFAULT_RANGE;
+                }, 
+                form: [
+                    {
+                        "key": "telemetryPoint",
+                        "name": "Telemetry Point",
+                        "control": "textfield",
+                        "required": true,
+                        "cssClass": "l-input-lg"
+                    },
+                    {
+                        "key": "samples",
+                        "name": "Samples to Average",
+                        "control": "textfield",
+                        "required": true,
+                        "cssClass": "l-input-sm"
+                    },        
+                    {
+                        
+                        "name": "Configured Y-axis",
+                        "control": 'select',
+                        "options": [
+                          {
+                            "name": 'DN',
+                            "value": {"key": "dn", "name":"DN", "hints": {"range": 1, "priority": 1}}
+                          },
+                          {
+                            "name": 'EU',
+                            "value": {"key": "eu", "name":"EU", "hints": {"range": 1, "priority": 1}}
+                          }
+                        ],
+                        "cssClass": 'l-inline',
+                        "property": ['telemetry', 'values',openmct.time.getAllTimeSystems().filter(ts => ts.key !== 'utc').length+1],
+
+                      }
+                ]
+            });
+            openmct.telemetry.addProvider(new OMMMeanTelemetryProvider(openmct));
+        };
+        
+    }
+
+    return plugin;
+});

--- a/src/OMMTelemetryMean/src/MockTelemetryApi.js
+++ b/src/OMMTelemetryMean/src/MockTelemetryApi.js
@@ -1,0 +1,108 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2023, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+define([], function () {
+
+    function MockTelemetryApi() {
+        this.createSpy('subscribe');
+        this.createSpy('getMetadata');
+
+        this.metadata = this.createMockMetadata();
+        this.setDefaultRangeTo('defaultRange');
+        this.unsubscribe = jasmine.createSpy('unsubscribe');
+        this.mockReceiveTelemetry = this.mockReceiveTelemetry.bind(this);
+    }
+
+    MockTelemetryApi.prototype.subscribe = function () {
+        return this.unsubscribe;
+    };
+
+    MockTelemetryApi.prototype.getMetadata = function (object) {
+        return this.metadata;
+    };
+
+    MockTelemetryApi.prototype.request = jasmine.createSpy('request');
+
+    MockTelemetryApi.prototype.getValueFormatter = function (valueMetadata) {
+        const mockValueFormatter = jasmine.createSpyObj("valueFormatter", [
+            "parse"
+        ]);
+
+        mockValueFormatter.parse.and.callFake(function (value) {
+            return value[valueMetadata.key];
+        });
+
+        return mockValueFormatter;
+    };
+
+    MockTelemetryApi.prototype.mockReceiveTelemetry = function (newTelemetryDatum) {
+        const subscriptionCallback = this.subscribe.calls.mostRecent().args[1];
+        subscriptionCallback(newTelemetryDatum);
+    };
+
+    /**
+     * @private
+     */
+    MockTelemetryApi.prototype.onRequestReturn = function (telemetryData) {
+        this.requestTelemetry = telemetryData;
+    };
+
+    /**
+     * @private
+     */
+    MockTelemetryApi.prototype.setDefaultRangeTo = function (rangeKey) {
+        const mockMetadataValue = {
+            key: rangeKey
+        };
+        this.metadata.valuesForHints.and.returnValue([mockMetadataValue]);
+    };
+
+    /**
+     * @private
+     */
+    MockTelemetryApi.prototype.createMockMetadata = function () {
+        const mockMetadata = jasmine.createSpyObj("metadata", [
+            'dn',
+            'eu',
+            'valuesForHints'
+        ]);
+
+        mockMetadata.value.and.callFake(function (key) {
+            return {
+                key: key
+            };
+        });
+
+        return mockMetadata;
+    };
+
+    /**
+     * @private
+     */
+    MockTelemetryApi.prototype.createSpy = function (functionName) {
+        this[functionName] = this[functionName].bind(this);
+        spyOn(this, functionName);
+        this[functionName].and.callThrough();
+    };
+
+    return MockTelemetryApi;
+});

--- a/src/OMMTelemetryMean/src/OMMMeanTelemetryProvider.js
+++ b/src/OMMTelemetryMean/src/OMMMeanTelemetryProvider.js
@@ -1,0 +1,125 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2023, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+define([
+    'objectUtils',
+    './TelemetryAverager'
+], function (objectUtils, TelemetryAverager) {
+
+    function OMMMeanTelemetryProvider(openmct) {
+        this.openmct = openmct;
+        this.telemetryAPI = openmct.telemetry;
+        this.timeAPI = openmct.time;
+        this.objectAPI = openmct.objects;
+        this.perObjectProviders = {};
+    }
+    OMMMeanTelemetryProvider.prototype.canProvideTelemetry = function (domainObject) {
+        return domainObject.type === 'telemetry-mean';
+    };
+
+    OMMMeanTelemetryProvider.prototype.supportsRequest =
+        OMMMeanTelemetryProvider.prototype.supportsSubscribe =
+            OMMMeanTelemetryProvider.prototype.canProvideTelemetry;
+
+    OMMMeanTelemetryProvider.prototype.subscribe = function (domainObject, callback) {
+        let wrappedUnsubscribe;
+        let unsubscribeCalled = false;
+        const objectId = objectUtils.parseKeyString(domainObject.telemetryPoint);
+        const samples = domainObject.samples;
+        const rangeidx = domainObject.rangeidx;
+        const domainValues = domainObject.telemetry.values;
+        this.objectAPI.get(objectId)
+            .then(function (linkedDomainObject) {
+                if (!unsubscribeCalled) {
+                    
+                    wrappedUnsubscribe = this.subscribeToAverage(linkedDomainObject, samples, domainValues, rangeidx, callback);
+                }
+            }.bind(this))
+            .catch(logError);
+
+        return function unsubscribe() {
+            unsubscribeCalled = true;
+            if (wrappedUnsubscribe !== undefined) {
+                wrappedUnsubscribe();
+            }
+        };
+    };
+
+    OMMMeanTelemetryProvider.prototype.subscribeToAverage = function (domainObject, samples, domainValues,rangeidx,callback) {
+        const telemetryAverager = new TelemetryAverager(this.telemetryAPI, this.timeAPI, domainObject, samples,domainValues,rangeidx, callback);
+        const createAverageDatum = telemetryAverager.createAverageDatum.bind(telemetryAverager);
+
+        return this.telemetryAPI.subscribe(domainObject, createAverageDatum);
+    };
+
+    OMMMeanTelemetryProvider.prototype.request = function (domainObject, request) {
+        const objectId = objectUtils.parseKeyString(domainObject.telemetryPoint);
+        const samples = domainObject.samples;
+        const rangeidx = domainObject.rangeidx;
+        const domainValues = domainObject.telemetry.values;
+        // Must clear the plot object because every query requires a re-calculate to be accurate. 
+        openmct.objectViews.emit('clearData',domainObject);
+        return this.objectAPI.get(objectId).then(function (linkedDomainObject) {
+            return this.requestAverageTelemetry(linkedDomainObject, request, samples, domainValues, rangeidx);
+        }.bind(this));
+    };
+
+    /**
+     * @private
+     */
+    OMMMeanTelemetryProvider.prototype.requestAverageTelemetry = function (domainObject, request, samples, domainValues,rangeidx) {
+        const averageData = [];
+        const addToAverageData = averageData.push.bind(averageData);
+        const telemetryAverager = new TelemetryAverager(this.telemetryAPI, this.timeAPI, domainObject, samples, domainValues, rangeidx, addToAverageData);
+        const createAverageDatum = telemetryAverager.createAverageDatum.bind(telemetryAverager);
+        const timeAPI=this.timeAPI;
+
+        return this.telemetryAPI.request(domainObject, request).then(function (telemetryData) {
+            // Need to ensure the data is sorted by the current domain. 
+            // Especially needed because during realtime passes telemetry fills in from behind
+            // So each update of this isn't guarenteed to have time-sorted telemetry in pass. 
+            const domainKey = timeAPI.timeSystem().key;
+            telemetryData.sort((a, b) => a[domainKey] - b[domainKey]); 
+            telemetryData.forEach(createAverageDatum);
+            return averageData;
+        });
+    };
+
+    /**
+     * @private
+     */
+    OMMMeanTelemetryProvider.prototype.getLinkedObject = function (domainObject) {
+        const objectId = objectUtils.parseKeyString(domainObject.telemetryPoint);
+
+        return this.objectAPI.get(objectId);
+    };
+
+    function logError(error) {
+        if (error.stack) {
+            console.error(error.stack);
+        } else {
+            console.error(error);
+        }
+    }
+
+    return OMMMeanTelemetryProvider;
+});

--- a/src/OMMTelemetryMean/src/TelemetryAverager.js
+++ b/src/OMMTelemetryMean/src/TelemetryAverager.js
@@ -1,0 +1,116 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2023, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+define([], function () {
+
+    function TelemetryAverager(telemetryAPI, timeAPI, domainObject, samples, domainValues, rangeidx, averageDatumCallback) {
+        this.telemetryAPI = telemetryAPI;
+        this.timeAPI = timeAPI;
+        this.domainObject = domainObject;
+        this.samples = samples;
+        this.rangeidx = rangeidx; 
+        this.domainValues = domainValues;
+        this.averagingWindow = [];
+        this.rangeKey = undefined;
+        this.rangeFormatter = undefined;
+        this.setRangeKeyAndFormatter();
+        // Defined dynamically based on current time system
+        this.domainKey = undefined;
+        this.domainFormatter = undefined;
+
+        this.averageDatumCallback = averageDatumCallback;
+    }
+  
+    TelemetryAverager.prototype.createAverageDatum = function (telemetryDatum) {
+        this.setDomainKeyAndFormatter();
+        const timeValue = this.domainFormatter.parse(telemetryDatum);
+        const rangeValue = this.rangeFormatter.parse(telemetryDatum);
+
+        this.averagingWindow.push(rangeValue);
+
+        if (this.averagingWindow.length < this.samples) {
+            // We do not have enough data to produce an average
+            return;
+        } else if (this.averagingWindow.length > this.samples) {
+            //Do not let averaging window grow beyond defined sample size
+            this.averagingWindow.shift();
+        }
+
+        const averageValue = this.calculateMean();
+
+        const meanDatum = {};
+        meanDatum[this.domainKey] = timeValue;
+        meanDatum[this.rangeKey] = averageValue;
+
+        this.averageDatumCallback(meanDatum);
+    };
+
+    /**
+     * @private
+     */
+    TelemetryAverager.prototype.calculateMean = function () {
+        let sum = 0;
+        let i = 0;
+
+        for (; i < this.averagingWindow.length; i++) {
+            sum += this.averagingWindow[i];
+        }
+
+        return sum / this.averagingWindow.length;
+    };
+
+    /**
+     * The mean telemetry filter produces domain values in whatever time
+     * system is currently selected from the conductor. Because this can
+     * change dynamically, the averager needs to be updated regularly with
+     * the current domain.
+     * @private
+     */
+    TelemetryAverager.prototype.setDomainKeyAndFormatter = function () {
+        const domainKey = this.timeAPI.timeSystem().key;
+        if (domainKey !== this.domainKey) {
+            this.domainKey = domainKey;
+            this.domainFormatter = this.getFormatter(domainKey);
+        }
+    };
+
+    /**
+     * @private
+     */
+    TelemetryAverager.prototype.setRangeKeyAndFormatter = function () {
+        const metadatas = this.telemetryAPI.getMetadata(this.domainObject);
+        this.rangeKey = this.domainValues[this.rangeidx].key;
+        this.rangeFormatter = this.getFormatter(this.rangeKey);
+    };
+
+    /**
+     * @private
+     */
+    TelemetryAverager.prototype.getFormatter = function (key) {
+        const objectMetadata = this.telemetryAPI.getMetadata(this.domainObject);
+        const valueMetadata = objectMetadata.value(key);
+        
+        return this.telemetryAPI.getValueFormatter(valueMetadata);
+    };
+
+    return TelemetryAverager;
+});

--- a/src/constants.js
+++ b/src/constants.js
@@ -191,7 +191,37 @@ define([
             'frameEventStreamUrl'
         ]
     };
-
+    (function () {
+        var evrOverride= window.openmctMCWSConfig.overrideEVRColumns  === undefined;
+        if(!evrOverride){
+            var overRide=window.openmctMCWSConfig.overrideEVRColumns;
+            for (const column of overRide) {
+                switch (column.action) {
+                    case 'add':
+                        var usepos=column.position===undefined;
+                        if(!usepos){
+                           idx=column.position;
+                           CONSTANTS.EVR_RANGES.splice(idx,0,column.value);
+                           break;
+                           }
+                        else
+                           {
+                            CONSTANTS.EVR_RANGES.push(column.value);
+                            break;
+                           }
+                    case 'update':
+                        for (const [newkey, newvalue] of Object.entries(column.value)) {
+                            var index=CONSTANTS.EVR_RANGES.findIndex(item =>item.key===column.key);
+                            CONSTANTS.EVR_RANGES[index][newkey]=newvalue;
+                        };
+                        break;
+                    case 'remove':
+                       CONSTANTS.EVR_RANGES.splice(CONSTANTS.EVR_RANGES.findIndex(item =>item.key===column.key),1);
+                       break;
+                }
+            };
+        }
+    })();
     /**
      * An array of model properties that is necessary to provide channel
      * telemetry.

--- a/src/time/plugin.js
+++ b/src/time/plugin.js
@@ -80,15 +80,15 @@ export default function TimePlugin(options) {
             timeSystem: system.key,
             name: 'fixed'
         };
-        if( timeSystem.modeSettings && timeSystem.modeSettings['fixed']?.bounds){
-            systemOptions.bounds=timeSystem.modeSettings['fixed'].bounds;
+        if(timeSystem.modeSettings?.fixed?.bounds){
+            systemOptions.bounds=timeSystem.modeSettings.fixed.bounds;
 
         } else {
             systemOptions.bounds=BOUNDS_MAP[key];
         }
 
-        if (timeSystem.modeSettings && timeSystem.modeSettings['fixed']?.presets) {
-            systemOptions.presets = timeSystem.modeSettings['fixed'].presets;
+        if (timeSystem.modeSettings?.fixed?.presets) {
+            systemOptions.presets = timeSystem.modeSettings.fixed.presets;
         }
         if (timeSystem.limit) {
             systemOptions.limit = timeSystem.limit;
@@ -107,11 +107,11 @@ export default function TimePlugin(options) {
                 end: 5 * 60 * 1000
             }
             var presetConfig = []
-            if (timeSystem.modeSettings && timeSystem.modeSettings['utc.local']?.clockOffsets){
-                offsetConfig = timeSystem.modeSettings['utc.local'].clockOffsets
+            if (timeSystem.modeSettings?.realtime?.clockOffsets){
+                offsetConfig = timeSystem.modeSettings.realtime.clockOffsets
             }
-            if (timeSystem.modeSettings && timeSystem.modeSettings['utc.local']?.presets){
-                presetConfig = timeSystem.modeSettings['utc.local'].presets
+            if (timeSystem.modeSettings?.realtime?.presets){
+                presetConfig = timeSystem.modeSettings.realtime.presets
             }
             useUTCClock = true;
             menuOptions.push({
@@ -119,7 +119,7 @@ export default function TimePlugin(options) {
                 timeSystem: system.key,
                 clock: 'utc.local',
                 clockOffsets: offsetConfig,
-                presets: presetConfig
+                presets: presetConfig            
             });
         }
         if (options.allowRealtime && options.allowLAD) {
@@ -128,23 +128,16 @@ export default function TimePlugin(options) {
                 start: -30 * 60 * 1000,
                 end: 5 * 60 * 1000
             }
-            var presetConfig = []
-            if (timeSystem.modeSettings && timeSystem.modeSettings[key]?.clockOffsets){
-                offsetConfig = timeSystem.modeSettings[key].clockOffsets
-            }
-
-            if (timeSystem.modeSettings && timeSystem.modeSettings['utc.local']?.presets){
-                presetConfig = timeSystem.modeSettings['utc.local'].presets
+            if (timeSystem.modeSettings?.lad?.clockOffsets){
+                offsetConfig = timeSystem.modeSettings.lad.clockOffsets
             }
 
             install.ladClocks[key] = ladClock;
             openmct.time.addClock(ladClock);
             menuOptions.push({
-                name: 'realtime',
                 timeSystem: system.key,
                 clock: ladClock.key,
                 clockOffsets: offsetConfig,
-                presets: presetConfig
             });
         }
     });

--- a/src/time/plugin.js
+++ b/src/time/plugin.js
@@ -77,11 +77,10 @@ export default function TimePlugin(options) {
         openmct.time.addTimeSystem(system);
 
         const systemOptions = {
-            timeSystem: system.key
+            timeSystem: system.key,
+            name: 'fixed'
         };
         if( timeSystem.modeSettings && timeSystem.modeSettings['fixed']?.bounds){
-            // Required regardless of the time system's name. 
-            systemOptions.name='fixed';
             systemOptions.bounds=timeSystem.modeSettings['fixed'].bounds;
 
         } else {

--- a/src/types/ChannelType.js
+++ b/src/types/ChannelType.js
@@ -35,7 +35,13 @@ define([
         object.name = channel.channel_id + ' - ' + channel.channel_name;
         object.telemetry.channel_id = channel.channel_id;
         object.telemetry.definition = channel;
-
+        // Enforce SCLK to be shown even if the time system isn't available. 
+        object.telemetry.values.push({
+            name: "SCLK",
+            key: "sclk",
+            format: 'sclk.float64',
+            hints: {}
+        }); 
         if (channel.dn_to_eu === 'ON') {
             object.telemetry.defaultEU = true;
             object.telemetry.values.push({
@@ -77,18 +83,19 @@ define([
                 range: 6
             }
         });
-
+        /*
         object.telemetry.values.push({
             name: "DSS ID",
             key: "dss_id",
             format: "number",
             filters: ['equals']
         });
-
+        */
         if (channel.enumerations && channel.enumerations.length) {
             object.telemetry.values.push(
                 makeEnumerationRange(channel.enumerations)
             );
+            /* No need for status as that's covered in enum. 
             object.telemetry.values.push({
                 key: "status",
                 name: "Status",
@@ -96,7 +103,7 @@ define([
                 format: "string",
                 hints: {
                 }
-            });
+            });*/
         } else if (channel.data_type === 'BOOLEAN' ||
                    channel.data_type === 'BOOL') {
 
@@ -121,7 +128,7 @@ define([
                 }
             });
         }
-
+        /*
         object.telemetry.values.push({
             key: 'module',
             name: 'Module',
@@ -137,7 +144,7 @@ define([
                 possibleValues: [{value: true, label: "Realtime"}, {value: false, label: "Recorded"}]
             }]
         });
-        
+        */
         if (channel.status === 'missing') {
             object.status = 'missing';
         }


### PR DESCRIPTION
Closes #52 and addresses https://jira.jpl.nasa.gov/browse/OMM-104. 

Updates the timeSystems configuration in config.js and the time plugin to allow for setting of default bounds, presets, and clockoffsets for applicable modes (fixed/realtime), time systems (scet/ert/etc), and clocks (scet.lad, ert.lad, etc)
 
Settings are now modified in a modeSettings object that contains entries for
- fixed - allows setting of bounds and presets. 
- realtime - allows setting of clockoffsets and presets
- lad - allows setting of clockoffsets. 

Documentation is updated to show how these settings are used. 

Note: This requires the following change in core to apply the default time conductor bounds: 
https://github.com/nasa/openmct/pull/7964

Note: This will only apply to the first load. Another change to core needs to be enabled to enforce default bounds on time system change. I'm not sure where this might be applied and was hoping someone could point me to it. 

