### PR TITLE
Improved WS reconnect closures and increased connection batching interval

### DIFF
--- a/.webpack/webpack.prod.js
+++ b/.webpack/webpack.prod.js
@@ -11,5 +11,6 @@ const path = require('path');
 
 /** @type {import('webpack').Configuration} */
 module.exports =  merge(common, {
-    mode: 'production'
+    mode: 'production',
+    devtool: 'eval-source-map'
 });

--- a/.webpack/webpack.prod.js
+++ b/.webpack/webpack.prod.js
@@ -11,6 +11,5 @@ const path = require('path');
 
 /** @type {import('webpack').Configuration} */
 module.exports =  merge(common, {
-    mode: 'production',
-    devtool: 'eval-source-map'
+    mode: 'production'
 });

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "mini-css-extract-plugin": "2.7.6",
     "moment": "2.30.1",
     "node-bourbon": "^4.2.3",
-    "openmct": "nasa/openmct#omm-r5.3.0-rc3",
+    "openmct": "nasa/openmct#omm-r5.3.1",
     "printj": "1.3.1",
     "raw-loader": "^0.5.1",
     "resolve-url-loader": "5.0.0",

--- a/src/AMMOSPlugins.js
+++ b/src/AMMOSPlugins.js
@@ -96,7 +96,7 @@ define([
             openmct.install(RealtimeSessions.default());
 
             openmct.install(new HistoricalTelemetryPlugin(options));
-            openmct.install(new RealtimeTelemetryPlugin(vistaTime, options));
+            openmct.install(new RealtimeTelemetryPlugin.default(vistaTime, options));
             openmct.install(new TypePlugin.default());
             openmct.install(new TaxonomyPlugin(options.taxonomy));
             openmct.install(new LinkPlugin(options));

--- a/src/realtime/MCWSAlarmMessageStreamProvider.js
+++ b/src/realtime/MCWSAlarmMessageStreamProvider.js
@@ -1,41 +1,31 @@
-/*global define*/
+import MCWSStreamProvider from './MCWSStreamProvider';
 
-define([
-    './MCWSStreamProvider'
-], function (
-    MCWSStreamProvider
-) {
-    'use strict';
+/**
+ * Provides real-time streaming DataProduct data.
+ * @memberof {vista/telemetry}
+ */
+class MCWSAlarmMessageStreamProvider extends MCWSStreamProvider {
+    constructor(openmct, vistaTime) {
+        super(openmct, vistaTime);
+    }
 
-    /**
-     * Provides real-time streaming DataProduct data.
-     * @constructor
-     * @augments {MCWSStreamProvider}
-     * @memberof {vista/telemetry}
-     */
-    var MCWSAlarmMessageStreamProvider = MCWSStreamProvider.extend({
-        constructor: function (openmct, vistaTime) {
-            MCWSStreamProvider.call(this, openmct, vistaTime);
-        }
-    });
+    getUrl(domainObject) {
+        return domainObject.telemetry?.alarmMessageStreamUrl;
+    }
 
-    MCWSAlarmMessageStreamProvider.prototype.getUrl = function (domainObject) {
-        return domainObject.telemetry && domainObject.telemetry.alarmMessageStreamUrl;
-    };
-
-    MCWSAlarmMessageStreamProvider.prototype.getKey = function (domainObject) {
+    getKey(domainObject) {
         return domainObject.telemetry.key;
-    };
+    }
 
-    MCWSAlarmMessageStreamProvider.prototype.getProperty = function (domainObject) {
+    getProperty(domainObject) {
         return domainObject.telemetry.property;
-    };
+    }
 
-    MCWSAlarmMessageStreamProvider.prototype.notifyWorker = function (key, value) {
-        MCWSStreamProvider.prototype.notifyWorker.call(this, key, value);
-    };
+    notifyWorker(key, value) {
+        super.notifyWorker(key, value);
+    }
 
-    MCWSAlarmMessageStreamProvider.prototype.subscribe = function (domainObject, callback, options) {
+    subscribe(domainObject, callback, options) {
         let { telemetry: { alarmLevel = 'any'} = {}} = domainObject;
         alarmLevel = alarmLevel.toUpperCase();
         let objects = [
@@ -74,13 +64,12 @@ define([
             object.telemetry.values = domainObject.telemetry.values;
         });
 
-        let unsubscribers = objects.map(object => MCWSStreamProvider.prototype.subscribe.call(this, object, callback, options));
+        let unsubscribers = objects.map(object => super.subscribe(object, callback, options));
 
         return () => {
             unsubscribers.forEach(unsubscribe => unsubscribe());
         };
-
     }
+}
 
-    return MCWSAlarmMessageStreamProvider;
-});
+export default MCWSAlarmMessageStreamProvider;

--- a/src/realtime/MCWSAlarmMessageStreamProvider.js
+++ b/src/realtime/MCWSAlarmMessageStreamProvider.js
@@ -5,10 +5,6 @@ import MCWSStreamProvider from './MCWSStreamProvider';
  * @memberof {vista/telemetry}
  */
 class MCWSAlarmMessageStreamProvider extends MCWSStreamProvider {
-    constructor(openmct, vistaTime) {
-        super(openmct, vistaTime);
-    }
-
     getUrl(domainObject) {
         return domainObject.telemetry?.alarmMessageStreamUrl;
     }
@@ -19,10 +15,6 @@ class MCWSAlarmMessageStreamProvider extends MCWSStreamProvider {
 
     getProperty(domainObject) {
         return domainObject.telemetry.property;
-    }
-
-    notifyWorker(key, value) {
-        super.notifyWorker(key, value);
     }
 
     subscribe(domainObject, callback, options) {

--- a/src/realtime/MCWSChannelStreamProvider.js
+++ b/src/realtime/MCWSChannelStreamProvider.js
@@ -1,31 +1,21 @@
-/*global define*/
+import MCWSStreamProvider from './MCWSStreamProvider';
 
-define([
-    './MCWSStreamProvider'
-], function (
-    MCWSStreamProvider
-) {
-    'use strict';
+/**
+ * Provides real-time streaming channel data.
+ * @memberof {vista/telemetry}
+ */
+class MCWSChannelStreamProvider extends MCWSStreamProvider {
+    getUrl(domainObject) {
+        return domainObject.telemetry?.channelStreamUrl;
+    }
 
-    /**
-     * Provides real-time streaming channel data.
-     * @constructor
-     * @augments {MCWSStreamProvider}
-     * @memberof {vista/telemetry}
-     */
-    var MCWSChannelStreamProvider = MCWSStreamProvider.extend({});
-
-    MCWSChannelStreamProvider.prototype.getUrl = function (domainObject) {
-        return domainObject.telemetry && domainObject.telemetry.channelStreamUrl;
-    };
-
-    MCWSChannelStreamProvider.prototype.getKey = function (domainObject) {
+    getKey(domainObject) {
         return domainObject.telemetry.channel_id;
-    };
+    }
 
-    MCWSChannelStreamProvider.prototype.getProperty = function () {
+    getProperty() {
         return 'channel_id';
-    };
+    }
+}
 
-    return MCWSChannelStreamProvider;
-});
+export default MCWSChannelStreamProvider;

--- a/src/realtime/MCWSCommandStreamProvider.js
+++ b/src/realtime/MCWSCommandStreamProvider.js
@@ -1,34 +1,24 @@
-/*global define*/
+import MCWSStreamProvider from './MCWSStreamProvider';
 
-define([
-    './MCWSStreamProvider'
-], function (
-    MCWSStreamProvider
-) {
-    'use strict';
+/**
+ * Provides real-time streaming CommandEvent data.
+ * @memberof {vista/telemetry}
+ */
+class MCWSCommandStreamProvider extends MCWSStreamProvider {
+    getUrl(domainObject) {
+        return domainObject.telemetry?.commandEventStreamUrl;
+    }
 
-    /**
-     * Provides real-time streaming CommandEvent data.
-     * @constructor
-     * @augments {MCWSStreamProvider}
-     * @memberof {vista/telemetry}
-     */
-    var MCWSCommandStreamProvider = MCWSStreamProvider.extend({});
-
-    MCWSCommandStreamProvider.prototype.getUrl = function (domainObject) {
-        return domainObject.telemetry && domainObject.telemetry.commandEventStreamUrl;
-    };
-
-    MCWSCommandStreamProvider.prototype.getKey = function (domainObject) {
+    getKey() {
         // We return undefined so that we can match on undefined properties.
         return undefined;
-    };
+    }
 
-    MCWSCommandStreamProvider.prototype.getProperty = function () {
+    getProperty() {
         // We just want something that returns undefined so it matches the
         // key above.  Hacky.
         return 'some_undefined_property';
-    };
+    }
+}
 
-    return MCWSCommandStreamProvider;
-});
+export default MCWSCommandStreamProvider;

--- a/src/realtime/MCWSDataProductStreamProvider.js
+++ b/src/realtime/MCWSDataProductStreamProvider.js
@@ -1,41 +1,31 @@
-/*global define*/
+import MCWSStreamProvider from './MCWSStreamProvider';
 
-define([
-    './MCWSStreamProvider'
-], function (
-    MCWSStreamProvider
-) {
-    'use strict';
+/**
+ * Provides real-time streaming DataProduct data.
+ * @memberof {vista/telemetry}
+ */
+class MCWSDataProductStreamProvider extends MCWSStreamProvider {
+    constructor(openmct, vistaTime, options) {
+        super(openmct, vistaTime);
+        this.options = options;
+    }
 
-    /**
-     * Provides real-time streaming DataProduct data.
-     * @constructor
-     * @augments {MCWSStreamProvider}
-     * @memberof {vista/telemetry}
-     */
-    var MCWSDataProductStreamProvider = MCWSStreamProvider.extend({
-        constructor: function (openmct, vistaTime, options) {
-            this.options = options;
-            MCWSStreamProvider.call(this, openmct, vistaTime);
-        }
-    });
+    getUrl(domainObject) {
+        return domainObject.telemetry?.dataProductStreamUrl;
+    }
 
-    MCWSDataProductStreamProvider.prototype.getUrl = function (domainObject) {
-        return domainObject.telemetry && domainObject.telemetry.dataProductStreamUrl;
-    };
-
-    MCWSDataProductStreamProvider.prototype.getKey = function (domainObject) {
+    getKey() {
         // We return undefined so that we can match on undefined properties.
         return undefined;
-    };
+    }
 
-    MCWSDataProductStreamProvider.prototype.getProperty = function () {
+    getProperty() {
         // We just want something that returns undefined so it matches the
         // key above.  Hacky.
         return 'some_undefined_property';
-    };
+    }
 
-    MCWSDataProductStreamProvider.prototype.subscribe = function (domainObject, callback, options) {
+    subscribe(domainObject, callback, options) {
         function wrappedCallback(datum) {
             let sessionId = datum.session_id;
 
@@ -53,18 +43,18 @@ define([
             callback(datum);
         }
 
-        return MCWSStreamProvider.prototype.subscribe.call(this, domainObject, wrappedCallback, options);   
+        return super.subscribe(domainObject, wrappedCallback, options);   
     }
 
-    MCWSDataProductStreamProvider.prototype.notifyWorker = function (key, value) {
+    notifyWorker(key, value) {
         if (key === 'subscribe' && this.options.realtimeProductAPIDs
             && value.mcwsVersion === 3.2) {
             value.extraFilterTerms = {
                 apid: '(' + this.options.realtimeProductAPIDs.join(',') + ')'
             };
         }
-        MCWSStreamProvider.prototype.notifyWorker.call(this, key, value);
-    };
+        super.notifyWorker(key, value);
+    }
+}
 
-    return MCWSDataProductStreamProvider;
-});
+export default MCWSDataProductStreamProvider;

--- a/src/realtime/MCWSEVRLevelStreamProvider.js
+++ b/src/realtime/MCWSEVRLevelStreamProvider.js
@@ -1,35 +1,38 @@
-/*global define*/
+import MCWSStreamProvider from './MCWSStreamProvider';
 
-define([
-    './MCWSStreamProvider',
-    'lodash'
-], function (
-    MCWSStreamProvider,
-    _
-) {
-    'use strict';
-
+/**
+ * Provides real-time streaming EVR data by level.
+ * @memberof {vista/telemetry}
+ */
+class MCWSEVRLevelStreamProvider extends MCWSStreamProvider {
     /**
-     * Provides real-time streaming EVR data by level.
-     * @constructor
-     * @augments {MCWSStreamProvider}
-     * @memberof {vista/telemetry}
+     * Get the URL for streaming data for this domain object
+     * @param {Object} domainObject The domain object
+     * @returns {String} The URL to use for streaming
      */
-    var MCWSEVRLevelStreamProvider = MCWSStreamProvider.extend({});
-
-    MCWSEVRLevelStreamProvider.prototype.getUrl = function (domainObject) {
-        if (domainObject.telemetry && domainObject.telemetry.level) {
+    getUrl(domainObject) {
+        if (domainObject.telemetry?.evrStreamUrl) {
             return domainObject.telemetry.evrStreamUrl;
         }
-    };
+    }
 
-    MCWSEVRLevelStreamProvider.prototype.getProperty = function (domainObject) {
+    /**
+     * Get the property to use for this stream
+     * @param {Object} domainObject The domain object
+     * @returns {String} The property name
+     */
+    getProperty() {
         return 'level';
-    };
+    }
 
-    MCWSEVRLevelStreamProvider.prototype.getKey = function (domainObject) {
+    /**
+     * Get the key to use for this stream
+     * @param {Object} domainObject The domain object
+     * @returns {String} The key
+     */
+    getKey(domainObject) {
         return domainObject.telemetry.level;
-    };
+    }
+}
 
-    return MCWSEVRLevelStreamProvider;
-});
+export default MCWSEVRLevelStreamProvider;

--- a/src/realtime/MCWSFrameEventStreamProvider.js
+++ b/src/realtime/MCWSFrameEventStreamProvider.js
@@ -1,48 +1,62 @@
-/*global define*/
+import MCWSStreamProvider from './MCWSStreamProvider';
 
-define([
-    './MCWSStreamProvider'
-], function (
-    MCWSStreamProvider
-) {
-    'use strict';
+/**
+ * Provides real-time streaming DataProduct data.
+ * @memberof {vista/telemetry}
+ */
+class MCWSFrameEventStreamProvider extends MCWSStreamProvider {
+    /**
+     * @param {Object} openmct The Open MCT API
+     * @param {Object} vistaTime The Vista time API
+     */
+    constructor(openmct, vistaTime) {
+        super(openmct, vistaTime);
+    }
 
     /**
-     * Provides real-time streaming DataProduct data.
-     * @constructor
-     * @augments {MCWSStreamProvider}
-     * @memberof {vista/telemetry}
+     * Get the URL for streaming data for this domain object
+     * @param {Object} domainObject The domain object
+     * @returns {String} The URL to use for streaming
      */
-    var MCWSFrameEventStreamProvider = MCWSStreamProvider.extend({
-        constructor: function (openmct, vistaTime) {
-            MCWSStreamProvider.call(this, openmct, vistaTime);
-        }
-    });
+    getUrl(domainObject) {
+        return domainObject.telemetry?.frameEventStreamUrl;
+    }
 
-    MCWSFrameEventStreamProvider.prototype.getUrl = function (domainObject) {
-        return domainObject.telemetry && domainObject.telemetry.frameEventStreamUrl;
-    };
-
-    MCWSFrameEventStreamProvider.prototype.getKey = function (domainObject) {
+    /**
+     * Get the key to use for this stream
+     * @param {Object} domainObject The domain object
+     * @returns {String} The key
+     */
+    getKey(domainObject) {
         if (domainObject.type === 'vista.frame-event-filter') {
-            var frameEventType = domainObject.identifier.key.split(':')[0];
+            const frameEventType = domainObject.identifier.key.split(':')[0];
             return frameEventType;
         } else {
             return undefined;
         }
-    };
+    }
 
-    MCWSFrameEventStreamProvider.prototype.getProperty = function (domainObject) {
+    /**
+     * Get the property to use for this stream
+     * @param {Object} domainObject The domain object
+     * @returns {String} The property name
+     */
+    getProperty(domainObject) {
         if (domainObject.type === 'vista.frame-event-filter') {
             return 'message_type';
         } else {
             return 'some_undefined_property';
         }
-    };
+    }
 
-    MCWSFrameEventStreamProvider.prototype.notifyWorker = function (key, value) {
-        MCWSStreamProvider.prototype.notifyWorker.call(this, key, value);
-    };
+    /**
+     * Notify the worker about a new value
+     * @param {String} key The key
+     * @param {*} value The value
+     */
+    notifyWorker(key, value) {
+        super.notifyWorker(key, value);
+    }
+}
 
-    return MCWSFrameEventStreamProvider;
-});
+export default MCWSFrameEventStreamProvider;

--- a/src/realtime/MCWSFrameEventStreamProvider.js
+++ b/src/realtime/MCWSFrameEventStreamProvider.js
@@ -48,15 +48,6 @@ class MCWSFrameEventStreamProvider extends MCWSStreamProvider {
             return 'some_undefined_property';
         }
     }
-
-    /**
-     * Notify the worker about a new value
-     * @param {String} key The key
-     * @param {*} value The value
-     */
-    notifyWorker(key, value) {
-        super.notifyWorker(key, value);
-    }
 }
 
 export default MCWSFrameEventStreamProvider;

--- a/src/realtime/MCWSFrameSummaryStreamProvider.js
+++ b/src/realtime/MCWSFrameSummaryStreamProvider.js
@@ -1,42 +1,55 @@
-/*global define*/
+import MCWSStreamProvider from './MCWSStreamProvider';
 
-define([
-    './MCWSStreamProvider'
-], function (
-    MCWSStreamProvider
-) {
-    'use strict';
+/**
+ * Provides real-time streaming DataProduct data.
+ * @memberof {vista/telemetry}
+ */
+class MCWSFrameSummaryStreamProvider extends MCWSStreamProvider {
+    /**
+     * @param {Object} openmct The Open MCT API
+     * @param {Object} vistaTime The Vista time API
+     */
+    constructor(openmct, vistaTime) {
+        super(openmct, vistaTime);
+    }
 
     /**
-     * Provides real-time streaming DataProduct data.
-     * @constructor
-     * @augments {MCWSStreamProvider}
-     * @memberof {vista/telemetry}
+     * Get the URL for streaming data for this domain object
+     * @param {Object} domainObject The domain object
+     * @returns {String} The URL to use for streaming
      */
-    var MCWSFrameSummaryStreamProvider = MCWSStreamProvider.extend({
-        constructor: function (openmct, vistaTime) {
-            MCWSStreamProvider.call(this, openmct, vistaTime);
-        }
-    });
+    getUrl(domainObject) {
+        return domainObject.telemetry?.frameSummaryStreamUrl;
+    }
 
-    MCWSFrameSummaryStreamProvider.prototype.getUrl = function (domainObject) {
-        return domainObject.telemetry && domainObject.telemetry.frameSummaryStreamUrl;
-    };
-
-    MCWSFrameSummaryStreamProvider.prototype.getKey = function (domainObject) {
+    /**
+     * Get the key to use for this stream
+     * @param {Object} domainObject The domain object
+     * @returns {undefined} Always returns undefined to match on undefined properties
+     */
+    getKey() {
         // We return undefined so that we can match on undefined properties.
         return undefined;
-    };
+    }
 
-    MCWSFrameSummaryStreamProvider.prototype.getProperty = function () {
+    /**
+     * Get the property to use for this stream
+     * @returns {String} The property name
+     */
+    getProperty() {
         // We just want something that returns undefined so it matches the
-        // key above.  Hacky.
+        // key above. Hacky.
         return 'some_undefined_property';
-    };
+    }
 
-    MCWSFrameSummaryStreamProvider.prototype.notifyWorker = function (key, value) {
-        MCWSStreamProvider.prototype.notifyWorker.call(this, key, value);
-    };
+    /**
+     * Notify the worker about a new value
+     * @param {String} key The key
+     * @param {*} value The value
+     */
+    notifyWorker(key, value) {
+        super.notifyWorker(key, value);
+    }
+}
 
-    return MCWSFrameSummaryStreamProvider;
-});
+export default MCWSFrameSummaryStreamProvider;

--- a/src/realtime/MCWSFrameSummaryStreamProvider.js
+++ b/src/realtime/MCWSFrameSummaryStreamProvider.js
@@ -6,14 +6,6 @@ import MCWSStreamProvider from './MCWSStreamProvider';
  */
 class MCWSFrameSummaryStreamProvider extends MCWSStreamProvider {
     /**
-     * @param {Object} openmct The Open MCT API
-     * @param {Object} vistaTime The Vista time API
-     */
-    constructor(openmct, vistaTime) {
-        super(openmct, vistaTime);
-    }
-
-    /**
      * Get the URL for streaming data for this domain object
      * @param {Object} domainObject The domain object
      * @returns {String} The URL to use for streaming
@@ -40,15 +32,6 @@ class MCWSFrameSummaryStreamProvider extends MCWSStreamProvider {
         // We just want something that returns undefined so it matches the
         // key above. Hacky.
         return 'some_undefined_property';
-    }
-
-    /**
-     * Notify the worker about a new value
-     * @param {String} key The key
-     * @param {*} value The value
-     */
-    notifyWorker(key, value) {
-        super.notifyWorker(key, value);
     }
 }
 

--- a/src/realtime/MCWSMessageStreamProvider.js
+++ b/src/realtime/MCWSMessageStreamProvider.js
@@ -6,14 +6,6 @@ import MCWSStreamProvider from './MCWSStreamProvider';
  */
 class MCWSMessageStreamProvider extends MCWSStreamProvider {
     /**
-     * @param {Object} openmct The Open MCT API
-     * @param {Object} vistaTime The Vista time API
-     */
-    constructor(openmct, vistaTime) {
-        super(openmct, vistaTime);
-    }
-
-    /**
      * Subscribe to real-time updates for this domain object
      * @param {Object} domainObject The domain object
      * @param {Function} callback The callback to invoke with new data
@@ -74,15 +66,6 @@ class MCWSMessageStreamProvider extends MCWSStreamProvider {
         } else {
             return 'some_undefined_property';
         }
-    }
-
-    /**
-     * Notify the worker about a new value
-     * @param {String} key The key
-     * @param {*} value The value
-     */
-    notifyWorker(key, value) {
-        super.notifyWorker(key, value);
     }
 }
 

--- a/src/realtime/MCWSMessageStreamProvider.js
+++ b/src/realtime/MCWSMessageStreamProvider.js
@@ -1,30 +1,31 @@
-/*global define*/
+import MCWSStreamProvider from './MCWSStreamProvider';
 
-define([
-    './MCWSStreamProvider'
-], function (
-    MCWSStreamProvider
-) {
-    'use strict';
+/**
+ * Provides real-time streaming DataProduct data.
+ * @memberof {vista/telemetry}
+ */
+class MCWSMessageStreamProvider extends MCWSStreamProvider {
+    /**
+     * @param {Object} openmct The Open MCT API
+     * @param {Object} vistaTime The Vista time API
+     */
+    constructor(openmct, vistaTime) {
+        super(openmct, vistaTime);
+    }
 
     /**
-     * Provides real-time streaming DataProduct data.
-     * @constructor
-     * @augments {MCWSStreamProvider}
-     * @memberof {vista/telemetry}
+     * Subscribe to real-time updates for this domain object
+     * @param {Object} domainObject The domain object
+     * @param {Function} callback The callback to invoke with new data
+     * @param {Object} options Additional options
+     * @returns {Function} A function that will unsubscribe when called
      */
-    var MCWSMessageStreamProvider = MCWSStreamProvider.extend({
-        constructor: function (openmct, vistaTime) {
-            MCWSStreamProvider.call(this, openmct, vistaTime);
-        }
-    });
-
-    MCWSMessageStreamProvider.prototype.subscribe = function (domainObject, callback, options) {
-        var messageType = domainObject.identifier.key.split(':')[0];
+    subscribe(domainObject, callback, options) {
+        const messageType = domainObject.identifier.key.split(':')[0];
         options.filters = options.filters || {};
 
         if (messageType === 'CommandMessages') {
-            options.filters.message_type =  {'equals': [
+            options.filters.message_type = {'equals': [
                 'HardwareCommand',
                 'FlightSoftwareCommand',
                 'SequenceDirective',
@@ -36,33 +37,53 @@ define([
             ]};
         }
 
-        return MCWSStreamProvider.prototype.subscribe.call(this, domainObject, callback, options);
-    };
+        return super.subscribe(domainObject, callback, options);
+    }
 
-    MCWSMessageStreamProvider.prototype.getUrl = function (domainObject) {
-        return domainObject.telemetry && domainObject.telemetry.messageStreamUrl;
-    };
+    /**
+     * Get the URL for streaming data for this domain object
+     * @param {Object} domainObject The domain object
+     * @returns {String} The URL to use for streaming
+     */
+    getUrl(domainObject) {
+        return domainObject.telemetry?.messageStreamUrl;
+    }
 
-    MCWSMessageStreamProvider.prototype.getKey = function (domainObject) {
+    /**
+     * Get the key to use for this stream
+     * @param {Object} domainObject The domain object
+     * @returns {String|undefined} The key
+     */
+    getKey(domainObject) {
         //if it is the mock domainObject used in ClearDataOnMessage.js
         if (domainObject.identifier.key === 'message::clear-data-static-object') {
             return domainObject.telemetry.key;
         } else {
             return undefined;
         }
-    };
+    }
 
-    MCWSMessageStreamProvider.prototype.getProperty = function (domainObject) {
+    /**
+     * Get the property to use for this stream
+     * @param {Object} domainObject The domain object
+     * @returns {String} The property name
+     */
+    getProperty(domainObject) {
         if (domainObject.identifier.key === 'message::clear-data-static-object') {
             return domainObject.telemetry.property;
         } else {
             return 'some_undefined_property';
         }
-    };
+    }
 
-    MCWSMessageStreamProvider.prototype.notifyWorker = function (key, value) {
-        MCWSStreamProvider.prototype.notifyWorker.call(this, key, value);
-    };
+    /**
+     * Notify the worker about a new value
+     * @param {String} key The key
+     * @param {*} value The value
+     */
+    notifyWorker(key, value) {
+        super.notifyWorker(key, value);
+    }
+}
 
-    return MCWSMessageStreamProvider;
-});
+export default MCWSMessageStreamProvider;

--- a/src/realtime/MCWSPacketSummaryEventProvider.js
+++ b/src/realtime/MCWSPacketSummaryEventProvider.js
@@ -1,34 +1,38 @@
-/*global define*/
+import MCWSStreamProvider from './MCWSStreamProvider';
 
-define([
-    './MCWSStreamProvider'
-], function (
-    MCWSStreamProvider
-) {
-    'use strict';
+/**
+ * Provides real-time streaming PacketSummaryEvent data.
+ * @memberof {vista/telemetry}
+ */
+class MCWSPacketSummaryEventProvider extends MCWSStreamProvider {
+    /**
+     * Get the URL for streaming data for this domain object
+     * @param {Object} domainObject The domain object
+     * @returns {String} The URL to use for streaming
+     */
+    getUrl(domainObject) {
+        return domainObject.telemetry?.packetSummaryEventStreamUrl;
+    }
 
     /**
-     * Provides real-time streaming PacketSummaryEvent data.
-     * @constructor
-     * @augments {MCWSStreamProvider}
-     * @memberof {vista/telemetry}
+     * Get the key to use for this stream
+     * @param {Object} domainObject The domain object
+     * @returns {undefined} Always returns undefined to match on undefined properties
      */
-    var MCWSPacketSummaryEventProvider = MCWSStreamProvider.extend({});
-
-    MCWSPacketSummaryEventProvider.prototype.getUrl = function (domainObject) {
-        return domainObject.telemetry && domainObject.telemetry.packetSummaryEventStreamUrl;
-    };
-
-    MCWSPacketSummaryEventProvider.prototype.getKey = function (domainObject) {
+    getKey() {
         // We return undefined so that we can match on undefined properties.
         return undefined;
-    };
+    }
 
-    MCWSPacketSummaryEventProvider.prototype.getProperty = function () {
+    /**
+     * Get the property to use for this stream
+     * @returns {String} The property name
+     */
+    getProperty() {
         // We just want something that returns undefined so it matches the
         // key above.  Hacky.
         return 'some_undefined_property';
-    };
+    }
+}
 
-    return MCWSPacketSummaryEventProvider;
-});
+export default MCWSPacketSummaryEventProvider;

--- a/src/realtime/MCWSStreamProvider.js
+++ b/src/realtime/MCWSStreamProvider.js
@@ -15,8 +15,6 @@ import GlobalStaleness from 'services/globalStaleness/globalStaleness';
  * @memberof vista/telemetry
  */
 
-const BENIGN_ERRORS = [1000, 1005];
-
 class MCWSStreamProvider {
     constructor(openmct, vistaTime) {
         this.openmct = openmct;

--- a/src/realtime/MCWSStreamProvider.js
+++ b/src/realtime/MCWSStreamProvider.js
@@ -57,7 +57,7 @@ class MCWSStreamProvider {
     }
 
     onmessage(message) {
-        const { data, url, key, values } = message.data;
+        const { data, url, key, values } = message;
         const subscriptions = (this.subscriptions[url] ?? {})[key] ?? [];
         const timestamp = Date.now();
 

--- a/src/realtime/MCWSStreamProvider.js
+++ b/src/realtime/MCWSStreamProvider.js
@@ -57,7 +57,8 @@ class MCWSStreamProvider {
     }
 
     onmessage(message) {
-        const { data, url, key, values } = message;
+        const data = message.data;
+        const { url, key, values } = data;
         const subscriptions = (this.subscriptions[url] ?? {})[key] ?? [];
         const timestamp = Date.now();
 

--- a/src/realtime/MCWSStreamProvider.js
+++ b/src/realtime/MCWSStreamProvider.js
@@ -72,11 +72,10 @@ class MCWSStreamProvider {
 
         //Communicate websocket timeout and errors to users
         if (data.onclose && data.code === 1006) {
-            this.openmct.notifications.error('Real-time data connection lost - data may not be displayed as expected. Code: 1006');
-            console.error(`Real-time data connection lost - data may not be displayed as expected.`);
-            console.log('onclose', data);
+            const message = `Real-time data connection lost - data may not be displayed as expected. Code: 1006`;
+            this.openmct.notifications.error(message);
+            console.error(message);
         } else if (data.onerror) {
-            console.log('onerror', data);
             this.openmct.notifications.error(`Websocket Error for ${url}?${data.query}, please see console for details`);
             console.error(`Websocket Error - Code: ${data.code}, Error: ${data.reason}`);
         }

--- a/src/realtime/MCWSStreamProvider.js
+++ b/src/realtime/MCWSStreamProvider.js
@@ -77,8 +77,8 @@ class MCWSStreamProvider {
             console.log('onclose', data);
         } else if (data.onerror) {
             console.log('onerror', data);
-            this.openmct.notifications.error('Websocket Error, please see console for details');
-            console.error(`Websocket Error - Code:${data.code}, Error:${data.reason}`);
+            this.openmct.notifications.error(`Websocket Error for ${url}?${data.query}, please see console for details`);
+            console.error(`Websocket Error - Code: ${data.code}, Error: ${data.reason}`);
         }
     }
 

--- a/src/realtime/MCWSStreamProvider.js
+++ b/src/realtime/MCWSStreamProvider.js
@@ -73,6 +73,7 @@ class MCWSStreamProvider {
         //Communicate websocket timeout and errors to users
         if (data.onclose && data.code === 1006) {
             const message = `Real-time data connection lost - data may not be displayed as expected. Code: 1006`;
+
             this.openmct.notifications.error(message);
             console.error(message);
         } else if (data.onerror) {

--- a/src/realtime/MCWSStreamProvider.js
+++ b/src/realtime/MCWSStreamProvider.js
@@ -215,7 +215,7 @@ class MCWSStreamProvider {
             key: this.getKey(domainObject),
             property: this.getProperty(domainObject),
             mcwsVersion: domainObject.telemetry.mcwsVersion,
-            extraFilterTerms: options?.filters ?? this.serializeFilters(options.filters)
+            extraFilterTerms: options?.filters ? this.serializeFilters(options.filters) : undefined
         };
 
         function unsubscribe() {

--- a/src/realtime/MCWSStreamWorkerScript.js
+++ b/src/realtime/MCWSStreamWorkerScript.js
@@ -205,10 +205,26 @@
      * @private
      */
     MCWSConnection.prototype.reconnect = function () {
-        var oldSocket = this.socket,
-            url = this.url,
+        var url = this.url,
+            property = this.property,
             subscribers = this.subscribers,
-            property = this.property;
+            topic = this.topic,
+            extraFilterTerms = this.extraFilterTerms,
+            globalFilters = this.globalFilters,
+            self = this,
+            oldSocket = this.socket;
+
+        // If we have a pooled connection and it's still open, just reuse it
+        if (this.poolTimeout && oldSocket && oldSocket.readyState === WebSocket.OPEN) {
+            debugLog('Reusing pooled WebSocket connection', {
+                url: url,
+                timestamp: Date.now(),
+                socketId: oldSocket.id
+            });
+            clearTimeout(this.poolTimeout);
+            this.poolTimeout = null;
+            return;
+        }
 
         debugLog('MCWSConnection.reconnect', { 
             url: url, 

--- a/src/realtime/MCWSStreamWorkerScript.js
+++ b/src/realtime/MCWSStreamWorkerScript.js
@@ -47,6 +47,7 @@
       this.subscribers[key] = (this.subscribers[key] ?? 0) + 1;
 
       if (this.subscribers[key] === 1) {
+        this.subscribeTime = Date.now();
         this.scheduleReconnect();
       }
     }
@@ -200,9 +201,10 @@
         clearTimeout(this.pending);
       }
 
-      this.reconnectStartTime = Date.now();
       this.pending = setTimeout(() => {
         this.pending = undefined;
+        const connectionTime = Date.now() - this.subscribeTime;
+        console.log('reconnect open - connection time:', connectionTime, 'ms');
         this.reconnect();
       }, 100); // Keep the 250ms timeout for better batching
     }
@@ -238,8 +240,6 @@
       // close old socket in new socket open to ensure
       // no data is lost
       this.socket.onopen = async () => {
-        const connectionTime = Date.now() - this.reconnectStartTime;
-        console.log('reconnect open - connection time:', connectionTime, 'ms');
         if (oldSocket) {
           try {
             oldSocket.onclose = null;

--- a/src/realtime/MCWSStreamWorkerScript.js
+++ b/src/realtime/MCWSStreamWorkerScript.js
@@ -85,8 +85,8 @@
       }
 
       if (this.extraFilterTerms) {
-        Object.keys(this.extraFilterTerms).forEach((term) => {
-          filter[term] = this.extraFilterTerms[term];
+        Object.keys(this.extraFilterTerms).forEach((key) => {
+          filter[key] = this.extraFilterTerms[key];
         });
       }
 

--- a/src/realtime/MCWSStreamWorkerScript.js
+++ b/src/realtime/MCWSStreamWorkerScript.js
@@ -154,17 +154,20 @@
             
       // no subscribers or no topic close existing socket
       // suppress errors as they are not useful
-      if (oldSocket && (Object.keys(subscribers).length < 1 || !this.topic)) {
-        try {
-          oldSocket.onclose = null;
-          oldSocket.onerror = null;
-          oldSocket.close();
-        } catch (e) {
-            // Suppress errors
+      if (Object.keys(subscribers).length < 1 || !this.topic) {
+        if (oldSocket) {
+          try {
+            oldSocket.onclose = null;
+            oldSocket.onerror = null;
+            oldSocket.close();
+          } catch (e) {
+              // Suppress errors
+          }
+
+          oldSocket = undefined;
+          this.socket = undefined;
         }
 
-        oldSocket = undefined;
-        this.socket = undefined;
         return;
       }
 

--- a/src/realtime/MCWSStreamWorkerScript.js
+++ b/src/realtime/MCWSStreamWorkerScript.js
@@ -207,7 +207,7 @@
         console.log('scheduleReconnectsetTimeout');
         this.pending = undefined;
         this.reconnect();
-      }, 100);
+      }, 250); // Keep the 250ms timeout for better batching
     }
 
     /**
@@ -216,67 +216,114 @@
      * @private
      */
     async reconnect() {
-      let oldSocket = this.socket;
-      const { url, subscribers, property } = this;
-      console.log('reconnect', url, subscribers, property);
-
-      // If there are no subscribers, or no topic,
-      // close the socket (if it exists) and return
-      if (Object.keys(subscribers).length < 1 || !this.topic) {
-        if (oldSocket) {
-          await this.closeSocket(oldSocket);
-          oldSocket = undefined;
+      // Cancel any in-progress reconnection
+      if (this.reconnecting) {
+        console.log('canceling in-progress reconnection for newer request');
+        if (this.pendingSocket) {
+          // Close the socket that's in the process of connecting without waiting
+          try {
+            this.pendingSocket.onopen = null;
+            this.pendingSocket.onclose = null;
+            this.pendingSocket.onerror = null;
+            this.pendingSocket.close();
+          } catch (e) {
+            // Suppress any errors from closing the pending socket
+            console.log('error closing pending socket:', e);
+          }
+          this.pendingSocket = null;
         }
-
-        return;
       }
+      
+      this.reconnecting = true;
+      
+      try {
+        let oldSocket = this.socket;
+        const { url, subscribers, property } = this;
+        console.log('reconnect', url, subscribers, property);
 
-      // Create a new WebSocket connection with the updated query parameters
-      this.socket = new WebSocket(`${this.url}?${this.query()}`);
-
-      this.socket.onopen = async () => {
-        console.log('reconnect open');
-        if (oldSocket) {
-          await this.closeSocket(oldSocket);
-          oldSocket = undefined;
+        // If there are no subscribers, or no topic,
+        // close the socket (if it exists) and return
+        if (Object.keys(subscribers).length < 1 || !this.topic) {
+          if (oldSocket) {
+            await this.closeSocket(oldSocket);
+            oldSocket = undefined;
+          }
+          
+          this.socket = undefined;
+          return;
         }
-      };
 
-      this.socket.onmessage = (message) => {
-        const data = JSON.parse(message.data);
+        // Create a new WebSocket connection with the updated query parameters
+        const newSocket = new WebSocket(`${this.url}?${this.query()}`);
+        this.pendingSocket = newSocket;
 
-        data.forEach((datum) => {
-          const key = datum[property];
-          if (subscribers[key] > 0) {
-            self.postMessage({
-              url: url,
-              key: key,
-              values: [datum]
+        newSocket.onopen = async () => {
+          console.log('reconnect open');
+          // Only proceed if this is still the current pending socket
+          if (this.pendingSocket === newSocket) {
+            this.socket = newSocket;
+            this.pendingSocket = null;
+            
+            if (oldSocket) {
+              await this.closeSocket(oldSocket);
+              oldSocket = undefined;
+            }
+          } else {
+            // This socket was superseded by a newer request
+            console.log('socket connection completed but was superseded, closing');
+            try {
+              newSocket.close();
+            } catch (e) {
+              // Suppress errors
+            }
+          }
+        };
+
+        newSocket.onmessage = (message) => {
+          // Only process messages if this is the current socket
+          if (this.socket === newSocket) {
+            const data = JSON.parse(message.data);
+            data.forEach((datum) => {
+              const key = datum[property];
+              if (subscribers[key] > 0) {
+                self.postMessage({
+                  url: url,
+                  key: key,
+                  values: [datum]
+                });
+              }
             });
           }
-        });
-      };
+        };
 
-      this.socket.onclose = (message) => {
-        console.log('reconnect onclose');
-        self.postMessage({
-          onclose: true,
-          code: message.code,
-          reason: message.reason
-        });
-      };
+        newSocket.onclose = (message) => {
+          // Only report closure if this is the current socket
+          if (this.socket === newSocket) {
+            console.log('reconnect onclose');
+            self.postMessage({
+              onclose: true,
+              code: message.code,
+              reason: message.reason
+            });
+          }
+        };
 
-      this.socket.onerror = (error) => {
-        console.log('reconnect onerror');
-        // Log the URL that failed to connect for better debugging
-        self.postMessage({
-          onerror: true,
-          url: this.url,
-          query: this.query(),
-          code: error.code || 'unavailable',
-          reason: error.reason || 'WebSocket error occurred, but browser did not provide detailed error information'
-        });
-      };
+        newSocket.onerror = (error) => {
+          // Only report errors if this is the current socket or pending socket
+          if (this.socket === newSocket || this.pendingSocket === newSocket) {
+            console.log('reconnect onerror');
+            self.postMessage({
+              onerror: true,
+              url: this.url,
+              query: this.query(),
+              code: error.code || 'unavailable',
+              reason: error.reason || 'WebSocket error occurred, but browser did not provide detailed error information'
+            });
+          }
+        };
+      } finally {
+        this.reconnecting = false;
+      }
     }
   }
 

--- a/src/realtime/MCWSStreamWorkerScript.js
+++ b/src/realtime/MCWSStreamWorkerScript.js
@@ -207,7 +207,7 @@
         console.log('scheduleReconnectsetTimeout');
         this.pending = undefined;
         this.reconnect();
-      }, 10);
+      }, 100);
     }
 
     /**

--- a/src/realtime/MCWSStreamWorkerScript.js
+++ b/src/realtime/MCWSStreamWorkerScript.js
@@ -224,6 +224,8 @@
       // suppress errors as they are not useful
       if (oldSocket && (Object.keys(subscribers).length < 1 || !this.topic)) {
         try {
+          oldSocket.onclose = null;
+          oldSocket.onerror = null;
           oldSocket.close();
         } catch (e) {
             // Suppress errors
@@ -243,6 +245,8 @@
         console.log('reconnect open');
         if (oldSocket) {
           try {
+            oldSocket.onclose = null;
+            oldSocket.onerror = null;
             oldSocket.close();
           } catch (e) {
             // Suppress errors

--- a/src/realtime/MCWSStreamWorkerScript.js
+++ b/src/realtime/MCWSStreamWorkerScript.js
@@ -75,7 +75,7 @@
      * @returns {string} the query string
      * @private
      */
-    query() {
+    getQueryString() {
       const filter = {
         session_id: this.topic?.number,
         topic: this.topic?.topic
@@ -235,7 +235,7 @@
       }
 
       // Create a new WebSocket connection with the updated query parameters
-      this.socket = new WebSocket(`${this.url}?${this.query()}`);
+      this.socket = new WebSocket(`${this.url}?${this.getQueryString()}`);
 
       // close old socket in new socket open to ensure
       // no data is lost
@@ -281,7 +281,7 @@
         self.postMessage({
           onerror: true,
           url: this.url,
-          query: this.query(),
+          query: this.getQueryString(),
           code: error.code || 'unavailable',
           reason: error.reason || 'WebSocket error occurred, but browser did not provide detailed error information'
         });

--- a/src/realtime/MCWSStreamWorkerScript.js
+++ b/src/realtime/MCWSStreamWorkerScript.js
@@ -140,7 +140,7 @@
       this.pending = setTimeout(() => {
         this.pending = undefined;
         this.reconnect();
-      }, 10);
+      }, 100);
     }
 
     /**

--- a/src/realtime/MCWSStreamWorkerScript.js
+++ b/src/realtime/MCWSStreamWorkerScript.js
@@ -136,7 +136,7 @@
       const oldScheduleReconnectTime = this.scheduleReconnectTime ?? 0;
       this.scheduleReconnectTime = Date.now();
       const timeDifference = this.scheduleReconnectTime - oldScheduleReconnectTime;
-      console.log('scheduleReconnect time difference:', timeDifference, 'ms');
+      console.log(`scheduleReconnect for ${this.getQueryString()} time difference: ${timeDifference}ms`);
 
       if (this.pending) {
         clearTimeout(this.pending);

--- a/src/realtime/MCWSStreamWorkerScript.js
+++ b/src/realtime/MCWSStreamWorkerScript.js
@@ -222,8 +222,8 @@
           onerror: true,
           url: this.url,
           query: this.getQueryString(),
-          code: error.code || 'unavailable',
-          reason: error.reason || 'WebSocket error occurred, but browser did not provide detailed error information'
+          code: error.code ?? 'unavailable',
+          reason: error.reason ?? 'WebSocket error occurred, but browser did not provide detailed error information'
         });
       };
     }

--- a/src/realtime/MCWSStreamWorkerScript.js
+++ b/src/realtime/MCWSStreamWorkerScript.js
@@ -133,11 +133,6 @@
      * @private
      */
     scheduleReconnect() {
-      const oldScheduleReconnectTime = this.scheduleReconnectTime ?? 0;
-      this.scheduleReconnectTime = Date.now();
-      const timeDifference = this.scheduleReconnectTime - oldScheduleReconnectTime;
-      console.log(`scheduleReconnect for ${this.getQueryString()} time difference: ${timeDifference}ms`);
-
       if (this.pending) {
         clearTimeout(this.pending);
       }
@@ -145,7 +140,7 @@
       this.pending = setTimeout(() => {
         this.pending = undefined;
         this.reconnect();
-      }, 100);
+      }, 10);
     }
 
     /**
@@ -208,7 +203,6 @@
       };
 
       this.socket.onclose = (message) => {
-        console.log('reconnect onclose');
         self.postMessage({
           onclose: true,
           code: message.code,
@@ -217,7 +211,6 @@
       };
 
       this.socket.onerror = (error) => {
-        console.log('reconnect onerror', error);
         self.postMessage({
           onerror: true,
           url: this.url,

--- a/src/realtime/MCWSStreamWorkerScript.js
+++ b/src/realtime/MCWSStreamWorkerScript.js
@@ -1,506 +1,313 @@
 /*global setTimeout,clearTimeout,self,WebSocket*/
 (function (self, WebSocket) {
-    "use strict";
+  "use strict";
 
-    var worker;
+  var worker;
 
-    // Add debug logging helper - only log connection pool related events
-    function debugLog(message, data) {
-        // Only log messages related to connection pooling
-        if (message.includes('pool') || 
-            message.includes('WebSocket') || 
-            message.includes('connection') ||
-            message.includes('reconnect')) {
-            self.postMessage({
-                debug: true,
-                message: message,
-                data: data
-            });
-        }
-    }
+  /**
+   * Represents a subscription to streaming channel data for
+   * a specific EVR or Channel.
+   * @typedef MCWSStreamSubscription
+   * @property {string} url the WebSocket URL to request data from
+   * @property {string} key the identifier for the specific Channel or EVR
+   * @property {string} property the name of the property to use when
+   *           filtering, and when looking up keys from data points
+   */
 
-    // Connection pool configuration
-    const CONNECTION_POOL_TIMEOUT = 10000; // 10 seconds before closing unused connections
+  /**
+   * Manages a connection to a specific WebSocket URL for
+   * streaming channel data. Post messages from the worker thread
+   * as data arrives. Recreates the underlying WebSocket
+   * as necessary when query parameters change.
+   * @param {string} url the WebSocket URL
+   * @param {string} property the property to filter on
+   * @param {Object} topic metadata about the topic to listen on
+   * @constructor
+   * @private
+   */
+  function MCWSConnection(url, property, topic, extraFilterTerms, globalFilters) {
+      this.url = url;
+      this.topic = topic;
+      this.subscribers = {};
+      this.property = property;
+      this.extraFilterTerms = extraFilterTerms;
+      this.globalFilters = globalFilters;
+  }
 
-    /**
-     * Represents a subscription to streaming channel data for
-     * a specific EVR or Channel.
-     * @typedef MCWSStreamSubscription
-     * @property {string} url the WebSocket URL to request data from
-     * @property {string} key the identifier for the specific Channel or EVR
-     * @property {string} property the name of the property to use when
-     *           filtering, and when looking up keys from data points
-     */
+  /**
+   * Notify the connection of a new subscription to the specified channel.
+   * MCWSConnection keeps a count of active subscriptions in order to
+   * adjust filtering parameters as necessary.
+   * @param {string} key the channel or module to subscribe to
+   * @private
+   */
+  MCWSConnection.prototype.subscribe = function (key) {
+      this.subscribers[key] = (this.subscribers[key] || 0) + 1;
+      if (this.subscribers[key] === 1) {
+          this.scheduleReconnect();
+      }
+  };
 
-    /**
-     * Manages a connection to a specific WebSocket URL for
-     * streaming channel data. Post messages from the worker thread
-     * as data arrives. Recreates the underlying WebSocket
-     * as necessary when query parameters change.
-     * @param {string} url the WebSocket URL
-     * @param {string} property the property to filter on
-     * @param {Object} topic metadata about the topic to listen on
-     * @constructor
-     * @private
-     */
-    function MCWSConnection(url, property, topic, extraFilterTerms, globalFilters) {
-        this.url = url;
-        this.topic = topic;
-        this.subscribers = {};
-        this.property = property;
-        this.extraFilterTerms = extraFilterTerms;
-        this.globalFilters = globalFilters;
-        this.poolTimeout = null;
-    }
+  /**
+   * Notify the connection that a subscription to the specified channel
+   * has ended.
+   * MCWSConnection keeps a count of active subscriptions in order to
+   * adjust filtering parameters as necessary.
+   * @param {string} key the channel or module to unsubscribe to
+   * @private
+   */
+  MCWSConnection.prototype.unsubscribe = function (key) {
+      this.subscribers[key] = (this.subscribers[key] || 0) - 1;
+      if (this.subscribers[key] < 1) {
+          delete this.subscribers[key];
+          this.scheduleReconnect();
+      }
+  };
 
-    /**
-     * Notify the connection of a new subscription to the specified channel.
-     * MCWSConnection keeps a count of active subscriptions in order to
-     * adjust filtering parameters as necessary.
-     * @param {string} key the channel or module to subscribe to
-     * @private
-     */
-    MCWSConnection.prototype.subscribe = function (key) {
-        // Only log first subscription and pool-related events
-        if (!this.subscribers[key]) {
-            debugLog('MCWSConnection.subscribe - first subscription', { url: this.url, key: key });
-        }
-        
-        // Clear any pending pool timeout
-        if (this.poolTimeout) {
-            debugLog('Clearing pool timeout - connection reused', { 
-                url: this.url, 
-                key: key,
-                timestamp: Date.now()
-            });
-            clearTimeout(this.poolTimeout);
-            this.poolTimeout = null;
-        }
-        
-        this.subscribers[key] = (this.subscribers[key] || 0) + 1;
-        if (this.subscribers[key] === 1) {
-            this.scheduleReconnect();
-        }
-    };
+  /**
+   * Construct a query string for this connection's current topic, session
+   * and subscription state.
+   * @returns {string} the query string
+   * @private
+   */
+  MCWSConnection.prototype.query = function () {
+      var filter = {
+          session_id: this.topic && this.topic.number,
+          topic: this.topic && this.topic.topic
+      };
 
-    /**
-     * Notify the connection that a subscription to the specified channel
-     * has ended.
-     * MCWSConnection keeps a count of active subscriptions in order to
-     * adjust filtering parameters as necessary.
-     * @param {string} key the channel or module to unsubscribe to
-     * @private
-     */
-    MCWSConnection.prototype.unsubscribe = function (key) {
-        this.subscribers[key] = (this.subscribers[key] || 0) - 1;
-        if (this.subscribers[key] < 1) {
-            delete this.subscribers[key];
-            this.scheduleReconnect();
-        }
-    };
+      if (this.property !== 'some_undefined_property') {
+          filter[this.property] =
+              '(' + Object.keys(this.subscribers).join(',') + ')';
+      }
 
-    /**
-     * Construct a query string for this connection's current topic, session
-     * and subscription state.
-     * @returns {string} the query string
-     * @private
-     */
-    MCWSConnection.prototype.query = function () {
-        var filter = {
-            session_id: this.topic && this.topic.number,
-            topic: this.topic && this.topic.topic
-        };
+      if (this.extraFilterTerms) {
+          Object.keys(this.extraFilterTerms).forEach(function (k) {
+              filter[k] = this.extraFilterTerms[k];
+          }, this);
+      }
 
-        if (this.property !== 'some_undefined_property') {
-            filter[this.property] =
-                '(' + Object.keys(this.subscribers).join(',') + ')';
-        }
+      if (this.globalFilters) {
+        Object.entries(this.globalFilters).forEach(([key, value]) => {
+          if (filter[key]) {
+            console.warn(`Global filter not applied for existing persisted filter for ${key}.`);
+          } else {
+            filter[key] = value;
+          }
+        });
+      }
 
-        if (this.extraFilterTerms) {
-            Object.keys(this.extraFilterTerms).forEach(function (k) {
-                filter[k] = this.extraFilterTerms[k];
-            }, this);
-        }
+      return 'filter=(' + Object.keys(filter).filter(function (key) {
+          return !!filter[key];
+      }).map(function (key) {
+          return key + '=' + filter[key];
+      }).join(',') + ')';
+  };
 
-        if (this.globalFilters) {
-          Object.entries(this.globalFilters).forEach(([key, value]) => {
-            if (filter[key]) {
-              debugLog('Global filter not applied for existing persisted filter', { key: key });
-              console.warn(`Global filter not applied for existing persisted filter for ${key}.`);
-            } else {
-              filter[key] = value;
-            }
+  /**
+   * Close any active WebSocket associated with this connection.
+   * @private
+   */
+  MCWSConnection.prototype.destroy = function () {
+      if (this.socket) {
+          this.socket.close();
+          delete this.socket;
+      }
+  };
+
+  /**
+   * Set the topic for the active session.
+   * @param {Object} topic metadata for the selected topic, as provided
+   *        by MCWS
+   * @private
+   */
+  MCWSConnection.prototype.setTopic = function (topic) {
+      this.topic = topic;
+      this.scheduleReconnect();
+  };
+
+  MCWSConnection.prototype.setGlobalFilters = function (filters) {
+      this.globalFilters = filters;
+      this.scheduleReconnect();
+  };
+
+  MCWSConnection.prototype.scheduleReconnect = function () {
+      if (this.pending) {
+          clearTimeout(this.pending);
+      }
+      this.pending = setTimeout(function () {
+          this.pending = undefined;
+          this.reconnect();
+      }.bind(this), 10);
+  };
+
+  /**
+   * Reestablish the connection to the WebSocket (typically called because
+   * filtering parameters have changed.)
+   * @private
+   */
+  MCWSConnection.prototype.reconnect = function () {
+      var oldSocket = this.socket,
+          url = this.url,
+          subscribers = this.subscribers,
+          property = this.property;
+
+      if (Object.keys(subscribers).length < 1 || !this.topic) {
+          if (oldSocket) {
+              oldSocket.close();
+              delete this.socket;
+          }
+          return;
+      }
+
+      this.socket = new WebSocket(this.url + "?" + this.query());
+
+      this.socket.onopen = function () {
+          if (oldSocket) {
+              oldSocket.close();
+          }
+      };
+
+      this.socket.onmessage = function (message) {
+          var data = JSON.parse(message.data);
+
+          data.forEach(function (datum) {
+              var key = datum[property];
+              if (subscribers[key] > 0) {
+                  self.postMessage({
+                      url: url,
+                      key: key,
+                      values: [ datum ]
+                  });
+              }
           });
-        }
+      };
 
-        var queryString = 'filter=(' + Object.keys(filter).filter(function (key) {
-            return !!filter[key];
-        }).map(function (key) {
-            return key + '=' + filter[key];
-        }).join(',') + ')';
-        
-        debugLog('Generated query string', { 
-            url: this.url, 
-            queryString: queryString,
-            subscribers: Object.keys(this.subscribers)
+      this.socket.onclose = function (message) {
+          self.postMessage({
+              onclose: true,
+              code: message.code,
+              reason: message.reason
+          });
+      };
+
+      this.socket.onerror = function (error) {
+          self.postMessage({
+              onerror: true,
+              code: error.code,
+              reason: error.reason
         });
-        
-        return queryString;
-    };
-
-    /**
-     * Close any active WebSocket associated with this connection.
-     * @private
-     */
-    MCWSConnection.prototype.destroy = function () {
-        if (this.poolTimeout) {
-            debugLog('Destroying pooled connection - clearing timeout', { 
-                url: this.url,
-                timestamp: Date.now()
-            });
-            clearTimeout(this.poolTimeout);
-            this.poolTimeout = null;
-        }
-        
-        if (this.socket) {
-            debugLog('Destroying connection', { 
-                url: this.url,
-                timestamp: Date.now(),
-                socketId: this.socket.id
-            });
-            this.socket.close();
-            delete this.socket;
-        }
-    };
-
-    /**
-     * Set the topic for the active session.
-     * @param {Object} topic metadata for the selected topic, as provided
-     *        by MCWS
-     * @private
-     */
-    MCWSConnection.prototype.setTopic = function (topic) {
-        this.topic = topic;
-        this.scheduleReconnect();
-    };
-
-    MCWSConnection.prototype.setGlobalFilters = function (filters) {
-        this.globalFilters = filters;
-        this.scheduleReconnect();
-    };
-
-    MCWSConnection.prototype.scheduleReconnect = function () {
-        if (this.pending) {
-            clearTimeout(this.pending);
-        }
-        this.pending = setTimeout(function () {
-            this.pending = undefined;
-            this.reconnect();
-        }.bind(this), 10);
-    };
-
-    /**
-     * Reestablish the connection to the WebSocket (typically called because
-     * filtering parameters have changed.)
-     * @private
-     */
-    MCWSConnection.prototype.reconnect = function () {
-        var url = this.url,
-            property = this.property,
-            subscribers = this.subscribers,
-            topic = this.topic,
-            extraFilterTerms = this.extraFilterTerms,
-            globalFilters = this.globalFilters,
-            self = this,
-            oldSocket = this.socket;
-
-        // If we have a pooled connection and it's still open, just reuse it
-        if (this.poolTimeout && oldSocket && oldSocket.readyState === WebSocket.OPEN) {
-            debugLog('Reusing pooled WebSocket connection', {
-                url: url,
-                timestamp: Date.now(),
-                socketId: oldSocket.id
-            });
-            clearTimeout(this.poolTimeout);
-            this.poolTimeout = null;
-            return;
-        }
-
-        debugLog('MCWSConnection.reconnect', { 
-            url: url, 
-            subscriberCount: Object.keys(subscribers).length,
-            hasTopic: !!this.topic,
-            timestamp: Date.now(),
-            oldSocketId: oldSocket ? oldSocket.id : null
-        });
-
-        // If no subscribers, don't immediately close - add to connection pool
-        if (Object.keys(subscribers).length < 1) {
-            if (!this.poolTimeout) {
-                debugLog('No subscribers, adding connection to pool', { 
-                    url: url,
-                    timestamp: Date.now(),
-                    socketId: this.socket ? this.socket.id : null
-                });
-                this.poolTimeout = setTimeout(function() {
-                    debugLog('Connection pool timeout reached, closing socket', { 
-                        url: url,
-                        timestamp: Date.now(),
-                        socketId: this.socket ? this.socket.id : null
-                    });
-                    if (this.socket) {
-                        this.socket.close();
-                        delete this.socket;
-                    }
-                    this.poolTimeout = null;
-                }.bind(this), CONNECTION_POOL_TIMEOUT);
-            }
-            return;
-        }
-
-        // No topic, close connection
-        if (!this.topic) {
-            if (oldSocket) {
-                debugLog('Closing socket - no topic', { 
-                    url: url,
-                    timestamp: Date.now(),
-                    socketId: oldSocket.id
-                });
-                oldSocket.close();
-                delete this.socket;
-            }
-            return;
-        }
-
-        var fullUrl = this.url + "?" + this.query();
-        var socketId = Date.now() + '-' + Math.random().toString(36).substr(2, 9);
-        debugLog('Creating new WebSocket', { 
-            fullUrl: fullUrl, 
-            socketId: socketId,
-            timestamp: Date.now()
-        });
-        
-        this.socket = new WebSocket(fullUrl);
-        this.socket.id = socketId;  // Add ID to socket object
-
-        this.socket.onopen = function () {
-            debugLog('WebSocket opened', { 
-                url: url,
-                timestamp: Date.now(),
-                socketId: socketId
-            });
-            if (oldSocket && oldSocket !== this.socket) {
-                debugLog('Closing old socket', { 
-                    url: url,
-                    timestamp: Date.now(),
-                    oldSocketId: oldSocket.id,
-                    newSocketId: this.socket.id
-                });
-                oldSocket.close();
-            }
-        }.bind(this);
-
-        this.socket.onmessage = function (message) {
-            var data = JSON.parse(message.data);
-
-            data.forEach(function (datum) {
-                var key = datum[property];
-                if (subscribers[key] > 0) {
-                    self.postMessage({
-                        url: url,
-                        key: key,
-                        values: [ datum ]
-                    });
-                }
-            });
-        };
-
-        this.socket.onclose = function (message) {
-            debugLog('WebSocket closed', { 
-                url: url, 
-                code: message.code, 
-                reason: message.reason,
-                timestamp: Date.now(),
-                socketId: socketId,
-                isPooled: !!this.poolTimeout
-            });
-            
-            // Only notify if this isn't a pooled connection being closed
-            if (!this.poolTimeout) {
-                self.postMessage({
-                    onclose: true,
-                    url: url,
-                    code: message.code,
-                    reason: message.reason
-                });
-            }
-        }.bind(this);
-
-        this.socket.onerror = function (error) {
-            debugLog('WebSocket error', { 
-                url: url, 
-                code: error.code, 
-                reason: error.reason,
-                timestamp: Date.now(),
-                socketId: socketId
-            });
-            self.postMessage({
-                onerror: true,
-                code: error.code,
-                reason: error.reason
-            });
-        };
-    };
+      };
+  };
 
 
-    /**
-     * Manages connections for streaming channel data on a background.
-     * Creates, updates, and releases connections as necessary when
-     * the set of subscriptions changes.
-     *
-     * Methods may be invoked by posting a message to the worker
-     * with an object containing `key` and `value` properties, where
-     * `key` is the method name and `value` is the argument to provide.
-     * @constructor
-     */
-    function MCWSStreamWorker() {
-        this.connections = {};
-    }
+  /**
+   * Manages connections for streaming channel data on a background.
+   * Creates, updates, and releases connections as necessary when
+   * the set of subscriptions changes.
+   *
+   * Methods may be invoked by posting a message to the worker
+   * with an object containing `key` and `value` properties, where
+   * `key` is the method name and `value` is the argument to provide.
+   * @constructor
+   */
+  function MCWSStreamWorker() {
+      this.connections = {};
+  }
 
-    /**
-     * Release all active WebSocket connections.
-     */
-    MCWSStreamWorker.prototype.reset = function () {
-        Object.keys(this.connections).forEach(function (url) {
-            this.connections[url].destroy();
-            delete this.connections[url];
-        }.bind(this));
-        delete this.activeTopic;
-        delete this.activeGlobalFilters;
-    };
+  /**
+   * Release all active WebSocket connections.
+   */
+  MCWSStreamWorker.prototype.reset = function () {
+      Object.keys(this.connections).forEach(function (url) {
+          this.connections[url].destroy();
+          delete this.connections[url];
+      }.bind(this));
+      delete this.activeTopic;
+      delete this.activeGlobalFilters;
+  };
 
-    /**
-     * Add a new active subscription.
-     * @param {MCWSStreamSubscription} subscription the subscription to obtain
-     */
-    MCWSStreamWorker.prototype.subscribe = function (subscription) {
-        const url = subscription.url;
-        const key = subscription.key;
-        const property = subscription.property;
-        const extraFilterTerms = subscription.extraFilterTerms;
-        const cacheKey = this.generateCacheKey(url, property, extraFilterTerms);
+  /**
+   * Add a new active subscription.
+   * @param {MCWSStreamSubscription} subscription the subscription to obtain
+   */
+  MCWSStreamWorker.prototype.subscribe = function (subscription) {
+      const url = subscription.url;
+      const key = subscription.key;
+      const property = subscription.property;
+      const extraFilterTerms = subscription.extraFilterTerms;
+      const cacheKey = this.generateCacheKey(url, property, extraFilterTerms);
 
-        debugLog('MCWSStreamWorker.subscribe', { 
-            url: url, 
-            key: key, 
-            property: property,
-            cacheKey: cacheKey,
-            hasExtraFilters: !!extraFilterTerms
-        });
+      if (!this.connections[cacheKey]) {
+          this.connections[cacheKey] = new MCWSConnection(
+              url,
+              property,
+              this.activeTopic,
+              extraFilterTerms,
+              this.activeGlobalFilters
+          );
+      }
 
-        if (!this.connections[cacheKey]) {
-            debugLog('Creating new connection', { cacheKey: cacheKey });
-            this.connections[cacheKey] = new MCWSConnection(
-                url,
-                property,
-                this.activeTopic,
-                extraFilterTerms,
-                this.activeGlobalFilters
-            );
-        }
+      this.connections[cacheKey].subscribe(key);
+  };
 
-        this.connections[cacheKey].subscribe(key);
-    };
+  MCWSStreamWorker.prototype.generateCacheKey = function (url, property, extraFilterTerms) {
+      let filterComponent = extraFilterTerms && Object.keys(extraFilterTerms)
+          .sort()
+          .map(filterKey => filterKey + '=' + extraFilterTerms[filterKey])
+          .join('&');
+      let cacheKey = url + '__' + property;
+      if (filterComponent && filterComponent.length > 0) {
+          cacheKey += '__' + filterComponent
+      }
+      return cacheKey;
+  }
 
-    MCWSStreamWorker.prototype.generateCacheKey = function (url, property, extraFilterTerms) {
-        let filterComponent = extraFilterTerms && Object.keys(extraFilterTerms)
-            .sort()
-            .map(filterKey => filterKey + '=' + extraFilterTerms[filterKey])
-            .join('&');
-        let cacheKey = url + '__' + property;
-        if (filterComponent && filterComponent.length > 0) {
-            cacheKey += '__' + filterComponent
-        }
-        return cacheKey;
-    }
+  /**
+   * Add a new active subscription.
+   * @param {MCWSStreamSubscription} subscription the subscription to release
+   */
+  MCWSStreamWorker.prototype.unsubscribe = function (subscription) {
+      var url = subscription.url,
+          key = subscription.key,
+          property = subscription.property,
+          extraFilterTerms = subscription.extraFilterTerms,
+          cacheKey = this.generateCacheKey(url, property, extraFilterTerms);
 
-    /**
-     * Add a new active subscription.
-     * @param {MCWSStreamSubscription} subscription the subscription to release
-     */
-    MCWSStreamWorker.prototype.unsubscribe = function (subscription) {
-        var url = subscription.url,
-            key = subscription.key,
-            property = subscription.property,
-            extraFilterTerms = subscription.extraFilterTerms,
-            cacheKey = this.generateCacheKey(url, property, extraFilterTerms);
+      if (this.connections[cacheKey]) {
+          this.connections[cacheKey].unsubscribe(key);
+      }
+  };
 
-        debugLog('MCWSStreamWorker.unsubscribe', { 
-            url: url, 
-            key: key, 
-            property: property,
-            cacheKey: cacheKey
-        });
-
-        if (this.connections[cacheKey]) {
-            this.connections[cacheKey].unsubscribe(key);
-        } else {
-            debugLog('Warning: Tried to unsubscribe from non-existent connection', { 
-                cacheKey: cacheKey 
-            });
-        }
-    };
-
-    /**
-     * Change the current topic selection.
-     * @param {Object} topic metadata about the selected topic
-     */
-    MCWSStreamWorker.prototype.topic = function (topic) {
-        this.activeTopic = topic;
-        Object.keys(this.connections).forEach(function (cacheKey) {
-            this.connections[cacheKey].setTopic(topic);
-        }.bind(this));
-    };
-
-    /**
-     * Change the global filters.
-     * @param {Object} filters metadata about the filters
-     */
-    MCWSStreamWorker.prototype.globalFilters = function (filters) {
-      this.activeGlobalFilters = filters;
+  /**
+   * Change the current topic selection.
+   * @param {Object} topic metadata about the selected topic
+   */
+  MCWSStreamWorker.prototype.topic = function (topic) {
+      this.activeTopic = topic;
       Object.keys(this.connections).forEach(function (cacheKey) {
-          this.connections[cacheKey].setGlobalFilters(filters);
+          this.connections[cacheKey].setTopic(topic);
       }.bind(this));
   };
 
-    worker = new MCWSStreamWorker();
-    self.onmessage = function (messageEvent) {
-        var data = messageEvent.data,
-            method = worker[data.key];
-        
-        // Only log specific worker messages to reduce noise
-        if (data.key === 'subscribe' || data.key === 'unsubscribe') {
-            debugLog('Worker received ' + data.key + ' message', { 
-                url: data.value.url,
-                key: data.value.key,
-                timestamp: Date.now()
-            });
-        }
-        
-        if (method) {
-            method.call(worker, data.value);
-        } else {
-            debugLog('Warning: Unknown method called on worker', { key: data.key });
-        }
-    };
+  /**
+   * Change the global filters.
+   * @param {Object} filters metadata about the filters
+   */
+  MCWSStreamWorker.prototype.globalFilters = function (filters) {
+    this.activeGlobalFilters = filters;
+    Object.keys(this.connections).forEach(function (cacheKey) {
+        this.connections[cacheKey].setGlobalFilters(filters);
+    }.bind(this));
+};
 
-    // Add handler in main thread to display debug logs
-    if (typeof window !== 'undefined') {
-        window.addEventListener('message', function(event) {
-            if (event.data && event.data.debug) {
-                console.log('[MCWSStreamWorker]', event.data.message, event.data.data);
-            }
-        });
-    }
+  worker = new MCWSStreamWorker();
+  self.onmessage = function (messageEvent) {
+      var data = messageEvent.data,
+          method = worker[data.key];
+      if (method) {
+          method.call(worker, data.value);
+      }
+  };
 
 }(self, WebSocket));

--- a/src/realtime/MCWSStreamWorkerScript.js
+++ b/src/realtime/MCWSStreamWorkerScript.js
@@ -206,7 +206,7 @@
         const connectionTime = Date.now() - this.subscribeTime;
         console.log('reconnect open - connection time:', connectionTime, 'ms');
         this.reconnect();
-      }, 100); // Keep the 250ms timeout for better batching
+      }, 150);
     }
 
     /**

--- a/src/realtime/plugin.js
+++ b/src/realtime/plugin.js
@@ -1,46 +1,30 @@
-define([
-    'services/filtering/FilterService',
-    './MCWSChannelStreamProvider',
-    './MCWSEVRStreamProvider',
-    './MCWSEVRLevelStreamProvider',
-    './MCWSCommandStreamProvider',
-    './MCWSPacketSummaryEventProvider',
-    './MCWSDataProductStreamProvider',
-    './MCWSMessageStreamProvider',
-    './MCWSFrameSummaryStreamProvider',
-    './MCWSFrameEventStreamProvider',
-    './MCWSAlarmMessageStreamProvider',
-], function (
-    filterServiceDefault,
-    MCWSChannelStreamProvider,
-    MCWSEVRStreamProvider,
-    MCWSEVRLevelStreamProvider,
-    MCWSCommandStreamProvider,
-    MCWSPacketSummaryEventProvider,
-    MCWSDataProductStreamProvider,
-    MCWSMessageStreamProvider,
-    MCWSFrameSummaryStreamProvider,
-    MCWSFrameEventStreamProvider,
-    MCWSAlarmMessageStreamProvider
-) {
+import filterService from 'services/filtering/FilterService';
+import MCWSChannelStreamProvider from './MCWSChannelStreamProvider';
+import MCWSEVRStreamProvider from './MCWSEVRStreamProvider';
+import MCWSEVRLevelStreamProvider from './MCWSEVRLevelStreamProvider';
+import MCWSCommandStreamProvider from './MCWSCommandStreamProvider';
+import MCWSPacketSummaryEventProvider from './MCWSPacketSummaryEventProvider';
+import MCWSDataProductStreamProvider from './MCWSDataProductStreamProvider';
+import MCWSMessageStreamProvider from './MCWSMessageStreamProvider';
+import MCWSFrameSummaryStreamProvider from './MCWSFrameSummaryStreamProvider';
+import MCWSFrameEventStreamProvider from './MCWSFrameEventStreamProvider';
+import MCWSAlarmMessageStreamProvider from './MCWSAlarmMessageStreamProvider';
 
-    function RealtimeTelemetryPlugin(vistaTime, options) {
-        return function install(openmct) {
-            filterServiceDefault.default(openmct, options.globalFilters);
+function RealtimeTelemetryPlugin(vistaTime, options) {
+    return function install(openmct) {
+        filterService(openmct, options.globalFilters);
 
-            openmct.telemetry.addProvider(new MCWSChannelStreamProvider(openmct, vistaTime));
-            openmct.telemetry.addProvider(new MCWSEVRStreamProvider(openmct, vistaTime));
-            openmct.telemetry.addProvider(new MCWSEVRLevelStreamProvider(openmct, vistaTime));
-            openmct.telemetry.addProvider(new MCWSCommandStreamProvider(openmct, vistaTime));
-            openmct.telemetry.addProvider(new MCWSPacketSummaryEventProvider(openmct, vistaTime));
-            openmct.telemetry.addProvider(new MCWSDataProductStreamProvider(openmct, vistaTime, options));
-            openmct.telemetry.addProvider(new MCWSMessageStreamProvider(openmct, vistaTime));
-            openmct.telemetry.addProvider(new MCWSFrameSummaryStreamProvider(openmct, vistaTime));
-            openmct.telemetry.addProvider(new MCWSFrameEventStreamProvider(openmct, vistaTime));
-            openmct.telemetry.addProvider(new MCWSAlarmMessageStreamProvider(openmct, vistaTime));
-        }
+        openmct.telemetry.addProvider(new MCWSChannelStreamProvider(openmct, vistaTime));
+        openmct.telemetry.addProvider(new MCWSEVRStreamProvider(openmct, vistaTime));
+        openmct.telemetry.addProvider(new MCWSEVRLevelStreamProvider(openmct, vistaTime));
+        openmct.telemetry.addProvider(new MCWSCommandStreamProvider(openmct, vistaTime));
+        openmct.telemetry.addProvider(new MCWSPacketSummaryEventProvider(openmct, vistaTime));
+        openmct.telemetry.addProvider(new MCWSDataProductStreamProvider(openmct, vistaTime, options));
+        openmct.telemetry.addProvider(new MCWSMessageStreamProvider(openmct, vistaTime));
+        openmct.telemetry.addProvider(new MCWSFrameSummaryStreamProvider(openmct, vistaTime));
+        openmct.telemetry.addProvider(new MCWSFrameEventStreamProvider(openmct, vistaTime));
+        openmct.telemetry.addProvider(new MCWSAlarmMessageStreamProvider(openmct, vistaTime));
     }
+}
 
-    return RealtimeTelemetryPlugin;
-
-});
+export default RealtimeTelemetryPlugin;


### PR DESCRIPTION
closes #292
closes #293 

Updated Realtime code to ES6 classes/syntax.

Increase reconnect debounce time from 10ms to 100ms to add additional time for connection batching.

When closing WebSockets (due to no subscribers or because of updated filters/topics) suppress any errors. In high latency environments, these sockets can be closed before even connecting, which will throw errors. Other errors can pop up due to high latency environments that are not useful to the end user as these connections are no longer being used (either being replaced with a new connection, once that connection opens so no data is lost or because there are no subscribers). These errors just cause confusion and serve no informational purpose.