### PR TITLE
Add session information to Export Historical Data filename

### DIFF
--- a/src/exportDataAction/ExportDataAction.js
+++ b/src/exportDataAction/ExportDataAction.js
@@ -1,4 +1,6 @@
 import ExportDataTask from './ExportDataTask';
+import SessionService from 'services/session/SessionService';
+import { formatNumberSequence } from '../utils/strings';
 
 /**
  * Implements the "Export Data" action, allowing data for Channels, EVRs,
@@ -16,6 +18,7 @@ class ExportDataAction {
     this.group = 'view';
     this.priority = 1;
     this.validTypes = validTypes;
+    this.sessionService = SessionService();
 
     this.openmct = openmct;
   }
@@ -66,8 +69,27 @@ class ExportDataAction {
     }
   }
 
+  historicalFilterString() {
+    const sessionFilter = this.sessionService.getHistoricalSessionFilter();
+
+    if (!sessionFilter) {
+      return '';
+    }
+
+    const forFilename = true;
+
+    return `${sessionFilter.host}_${formatNumberSequence(sessionFilter.numbers, forFilename)}`;
+  }
+
   runExportTask(domainObjects) {
-    const task = new ExportDataTask(this.openmct, domainObjects[0].name, domainObjects);
+    const historicalFilterString = this.historicalFilterString();
+    let filename = domainObjects[0].name;
+
+    if (historicalFilterString) {
+      filename = `${filename} - ${historicalFilterString}`;
+    }
+
+    const task = new ExportDataTask(this.openmct, filename, domainObjects);
 
     return task.invoke();
   }

--- a/src/utils/strings.js
+++ b/src/utils/strings.js
@@ -24,7 +24,7 @@ function snakeCaseToStartCase(str) {
 function formatNumberSequence(numbers, forFilename = false) {
   const sortedNumbers = numbers.map(Number).sort((a, b) => a - b);
   const rangeSeparator = forFilename ? '-' : '...';
-  const commaSeparator = forFilename ? '_' : ',';
+  const commaSeparator = forFilename ? '_' : ', ';
   let result = `${sortedNumbers[0]}`;
   let rangeLength = 1;
 
@@ -50,7 +50,7 @@ function formatNumberSequence(numbers, forFilename = false) {
   if (rangeLength > 2) {
     result += `${rangeSeparator}${sortedNumbers[sortedNumbers.length - 1]}`;
   } else if (rangeLength === 2) {
-    result += `, ${sortedNumbers[sortedNumbers.length - 1]}`;
+    result += `${commaSeparator}${sortedNumbers[sortedNumbers.length - 1]}`;
   }
 
   return result;

--- a/src/utils/strings.js
+++ b/src/utils/strings.js
@@ -21,8 +21,10 @@ function snakeCaseToStartCase(str) {
  * @param {Array<number|string>} numbers - Array of numbers to format
  * @returns {string} Formatted string representation
  */
-function formatNumberSequence(numbers) {
+function formatNumberSequence(numbers, forFilename = false) {
   const sortedNumbers = numbers.map(Number).sort((a, b) => a - b);
+  const rangeSeparator = forFilename ? '-' : '...';
+  const commaSeparator = forFilename ? '_' : ',';
   let result = `${sortedNumbers[0]}`;
   let rangeLength = 1;
 
@@ -34,19 +36,19 @@ function formatNumberSequence(numbers) {
       rangeLength++;
     } else {
       if (rangeLength > 2) {
-        result += `...${prev}`;
+        result += `${rangeSeparator}${prev}`;
       } else if (rangeLength === 2) {
-        result += `, ${prev}`;
+        result += `${commaSeparator}${prev}`;
       }
 
-      result += `, ${current}`;
+      result += `${commaSeparator}${current}`;
       rangeLength = 1;
     }
   }
 
   // Handle the last range if it exists
   if (rangeLength > 2) {
-    result += `...${sortedNumbers[sortedNumbers.length - 1]}`;
+    result += `${rangeSeparator}${sortedNumbers[sortedNumbers.length - 1]}`;
   } else if (rangeLength === 2) {
     result += `, ${sortedNumbers[sortedNumbers.length - 1]}`;
   }


### PR DESCRIPTION
closes #264 

This modifies how formatted number sequences are handled, adding an option for filename formatting. This also adds the historical session host and session number(s) to the filename of the exported historical data for added clarity.