### PR TITLE
Updating Historical Export Filenames to use the view name instead of the first child endpoint name

### DIFF
--- a/src/exportDataAction/ExportDataAction.js
+++ b/src/exportDataAction/ExportDataAction.js
@@ -49,7 +49,7 @@ class ExportDataAction {
 
   async exportData(domainObject) {
     if (this.hasHistoricalTelemetry(domainObject)) {
-      await this.runExportTask([domainObject]);
+      await this.runExportTask(domainObject.name, [domainObject]);
     } else {
       await this.exportCompositionData(domainObject);
     }
@@ -63,7 +63,7 @@ class ExportDataAction {
     );
 
     if (filteredComposition.length > 0) {
-      await this.runExportTask(filteredComposition);
+      await this.runExportTask(domainObject.name, filteredComposition);
     } else {
       this.openmct.notifications.info('No historical data to export');
     }
@@ -78,8 +78,8 @@ class ExportDataAction {
     return `${sessionFilter.host}_${filterString}`;
   }
 
-  runExportTask(domainObjects) {
-    let filename = domainObjects[0].name;
+  runExportTask(name, domainObjects) {
+    let filename = name;
     const sessionFilter = this.sessionService.getHistoricalSessionFilter();
 
     if (sessionFilter) {


### PR DESCRIPTION
Updated the "Export Historical Data" action's exported filename to be based off of the view instead of the first child endpoint's name. This should provide more clarity for the exported item.

Previously, if you have a channel table "My Table" with the channels, "CPU-001, PWR-021, THR-187" in it, the filename would have been, `CPU-001 - sessionhost_1_2.csv`, now it will be, `My Table - hostname_1_2.csv`, when exporting telemetry endpoint by itself, for instance "CPU-001", you will still get the relevant filename, `CPU-001 - hostname_1_2.csv`