### PR TITLE
Add session info in exported plot image filename

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "mini-css-extract-plugin": "2.7.6",
     "moment": "2.30.1",
     "node-bourbon": "^4.2.3",
-    "openmct": "nasa/openmct#omm-r5.3.1",
+    "openmct": "github:nasa/openmct#omm-r5.4.0-rc1",
     "prettier": "3.4.2",
     "printj": "1.3.1",
     "raw-loader": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "mini-css-extract-plugin": "2.7.6",
     "moment": "2.30.1",
     "node-bourbon": "^4.2.3",
-    "openmct": "github:nasa/openmct#omm-r5.4.0-rc1",
+    "openmct": "nasa/openmct#omm-r5.4.0-rc1",
     "prettier": "3.4.2",
     "printj": "1.3.1",
     "raw-loader": "^0.5.1",

--- a/src/actionModifiers/ImageExport/ImageExportModifier.js
+++ b/src/actionModifiers/ImageExport/ImageExportModifier.js
@@ -1,0 +1,15 @@
+import SessionService from 'services/session/SessionService';
+
+function imageExportModifier(openmct) {
+  const PNGImageExportAction = openmct.actions._allActions['export-as-png'];
+  const JPGImageExportAction = openmct.actions._allActions['export-as-jpg'];
+  const imageExportActions = [PNGImageExportAction, JPGImageExportAction].filter(Boolean);
+
+  imageExportActions.forEach((action) => {
+    action.appliesTo = (objectPath, view = {}) => {
+      return isPlotView(view);
+    };
+  });
+}
+
+export default imageExportModifier;

--- a/src/actionModifiers/ImageExport/ImageExportModifier.js
+++ b/src/actionModifiers/ImageExport/ImageExportModifier.js
@@ -1,15 +1,37 @@
 import SessionService from 'services/session/SessionService';
+import { formatNumberSequence } from 'ommUtils/strings';
 
 function imageExportModifier(openmct) {
   const PNGImageExportAction = openmct.actions._allActions['export-as-png'];
   const JPGImageExportAction = openmct.actions._allActions['export-as-jpg'];
   const imageExportActions = [PNGImageExportAction, JPGImageExportAction].filter(Boolean);
+  const sessionService = SessionService();
 
   imageExportActions.forEach((action) => {
-    action.appliesTo = (objectPath, view = {}) => {
-      return isPlotView(view);
+    const invoke = action.invoke;
+
+    action.invoke = (objectPath, view) => {
+      let filename = objectPath[0].name;
+      const sessionFilter = sessionService.getHistoricalSessionFilter();
+
+      if (sessionFilter) {
+        filename = `${filename} - ${historicalFilterString(sessionFilter)}`;
+      }
+
+      filename = `${filename} - plot`;
+
+      invoke(objectPath, view, filename);
     };
   });
+}
+
+function historicalFilterString(sessionFilter) {
+  let filterString = formatNumberSequence(sessionFilter.numbers);
+
+  filterString = filterString.replaceAll('...', '-');
+  filterString = filterString.replaceAll(', ', '_');
+
+  return `${sessionFilter.host}_${filterString}`;
 }
 
 export default imageExportModifier;

--- a/src/actionModifiers/plugin.js
+++ b/src/actionModifiers/plugin.js
@@ -1,7 +1,7 @@
 import preventImportIntoDatasetModifier from './preventImportIntoDatasetModifier';
 import importWithDatasetsModifier from './ImportExportWithDatasets/importWithDatasetsModifier';
 import warnMultipleDatasetsOnDuplicateModifier from './MultipleDatasets/warnMultipleDatasetsOnDuplicateModifier';
-// import warnMultipleDatasetsOnImportModifier from './MultipleDatasets/warnMultipleDatasetsOnImportModifier';
+import imageExportModifier from './ImageExport/ImageExportModifier';
 
 /**
  * DEPENDENCY: These modifiers have a dependency on Open MCT action internals.
@@ -12,7 +12,7 @@ function ActionModifiersPlugin() {
       preventImportIntoDatasetModifier(openmct);
       importWithDatasetsModifier(openmct);
       warnMultipleDatasetsOnDuplicateModifier(openmct);
-      // warnMultipleDatasetsOnImportModifier(openmct);
+      imageExportModifier(openmct);
     });
   };
 }


### PR DESCRIPTION
This change will add the session host and session numbers currently being used to filter the data in the exported filename of the plot image. This will provide contextual information for those viewing the image.

closes #225 