### PR TITLE
Account for network errors during user folder retrieval

### DIFF
--- a/.webpack/webpack.prod.js
+++ b/.webpack/webpack.prod.js
@@ -8,6 +8,5 @@ const common = require('./webpack.common');
 
 /** @type {import('webpack').Configuration} */
 module.exports = merge(common, {
-  mode: 'production',
-  devtool: 'source-map'
+  mode: 'production'
 });

--- a/.webpack/webpack.prod.js
+++ b/.webpack/webpack.prod.js
@@ -8,5 +8,6 @@ const common = require('./webpack.common');
 
 /** @type {import('webpack').Configuration} */
 module.exports = merge(common, {
-  mode: 'production'
+  mode: 'production',
+  devtool: 'source-map'
 });

--- a/src/persistence/BaseMCWSPersistenceProvider.js
+++ b/src/persistence/BaseMCWSPersistenceProvider.js
@@ -177,6 +177,7 @@ export default class BaseMCWSPersistenceProvider {
    */
   async createIfMissing(namespaceDefinition, userId) {
     const namespace = mcws.namespace(namespaceDefinition.url);
+    let non404Error;
 
     try {
       await namespace.read();
@@ -198,11 +199,18 @@ export default class BaseMCWSPersistenceProvider {
 
           return namespaceDefinition;
         } catch (e) {
-          console.error('Error creating namespace:', e);
-
-          return;
+          non404Error = e;
         }
+      } else {
+        non404Error = readError;
       }
+    }
+
+    if (non404Error) {
+      console.error('Error creating namespace:', non404Error);
+      this.openmct.notify.error(
+        `Error creating namespace: ${non404Error.message ?? 'Unknown error'}. Check network connection and try again.`
+      );
     }
 
     return;

--- a/src/persistence/BaseMCWSPersistenceProvider.js
+++ b/src/persistence/BaseMCWSPersistenceProvider.js
@@ -176,7 +176,6 @@ export default class BaseMCWSPersistenceProvider {
    * @returns {Promise.<NamespaceDefinition>|Promise.<undefined>}
    */
   async createIfMissing(namespaceDefinition, userId) {
-    console.log('createIfMissing', namespaceDefinition, userId);
     const namespace = mcws.namespace(namespaceDefinition.url);
 
     try {
@@ -184,9 +183,7 @@ export default class BaseMCWSPersistenceProvider {
 
       return namespaceDefinition;
     } catch (readError) {
-      console.log('readError', readError);
       if (readError.status === 404) {
-        console.log('404');
         try {
           await namespace.create();
 

--- a/src/persistence/BaseMCWSPersistenceProvider.js
+++ b/src/persistence/BaseMCWSPersistenceProvider.js
@@ -177,6 +177,7 @@ export default class BaseMCWSPersistenceProvider {
    */
   async createIfMissing(namespaceDefinition, userId) {
     const namespace = mcws.namespace(namespaceDefinition.url);
+    let non404Error;
 
     try {
       await namespace.read();
@@ -198,13 +199,18 @@ export default class BaseMCWSPersistenceProvider {
 
           return namespaceDefinition;
         } catch (e) {
-          console.error('Error creating namespace:', e);
-
-          return;
+          non404Error = e;
         }
       } else {
-        throw readError;
+        non404Error = readError;
       }
+    }
+
+    if (non404Error) {
+      console.error('Error creating namespace:', non404Error);
+      this.openmct.notify.error(
+        `Error creating namespace: ${non404Error.message ?? 'Unknown error'}. Check network connection and try again.`
+      );
     }
 
     return;

--- a/src/persistence/BaseMCWSPersistenceProvider.js
+++ b/src/persistence/BaseMCWSPersistenceProvider.js
@@ -202,10 +202,10 @@ export default class BaseMCWSPersistenceProvider {
 
           return;
         }
+      } else {
+        throw readError;
       }
     }
-
-    return;
   }
 
   /**

--- a/src/persistence/BaseMCWSPersistenceProvider.js
+++ b/src/persistence/BaseMCWSPersistenceProvider.js
@@ -177,7 +177,6 @@ export default class BaseMCWSPersistenceProvider {
    */
   async createIfMissing(namespaceDefinition, userId) {
     const namespace = mcws.namespace(namespaceDefinition.url);
-    let non404Error;
 
     try {
       await namespace.read();
@@ -199,18 +198,11 @@ export default class BaseMCWSPersistenceProvider {
 
           return namespaceDefinition;
         } catch (e) {
-          non404Error = e;
-        }
-      } else {
-        non404Error = readError;
-      }
-    }
+          console.error('Error creating namespace:', e);
 
-    if (non404Error) {
-      console.error('Error creating namespace:', non404Error);
-      this.openmct.notify.error(
-        `Error creating namespace: ${non404Error.message ?? 'Unknown error'}. Check network connection and try again.`
-      );
+          return;
+        }
+      }
     }
 
     return;

--- a/src/persistence/BaseMCWSPersistenceProvider.js
+++ b/src/persistence/BaseMCWSPersistenceProvider.js
@@ -202,6 +202,8 @@ export default class BaseMCWSPersistenceProvider {
 
           return;
         }
+      } else {
+        throw readError;
       }
     }
 

--- a/src/persistence/BaseMCWSPersistenceProvider.js
+++ b/src/persistence/BaseMCWSPersistenceProvider.js
@@ -176,6 +176,7 @@ export default class BaseMCWSPersistenceProvider {
    * @returns {Promise.<NamespaceDefinition>|Promise.<undefined>}
    */
   async createIfMissing(namespaceDefinition, userId) {
+    console.log('createIfMissing', namespaceDefinition, userId);
     const namespace = mcws.namespace(namespaceDefinition.url);
 
     try {
@@ -183,7 +184,9 @@ export default class BaseMCWSPersistenceProvider {
 
       return namespaceDefinition;
     } catch (readError) {
+      console.log('readError', readError);
       if (readError.status === 404) {
+        console.log('404');
         try {
           await namespace.create();
 

--- a/src/persistence/MCWSPersistenceProvider.js
+++ b/src/persistence/MCWSPersistenceProvider.js
@@ -38,7 +38,8 @@ export default class MCWSPersistenceProvider extends BaseMCWSPersistenceProvider
         return {
           identifier,
           type: 'unknown',
-          name: 'Error: ' + this.openmct.objects.makeKeyString(identifier)
+          name: 'Error: ' + this.openmct.objects.makeKeyString(identifier),
+          networkError: true
         };
       }
 

--- a/src/persistence/MCWSPersistenceProvider.js
+++ b/src/persistence/MCWSPersistenceProvider.js
@@ -32,7 +32,7 @@ export default class MCWSPersistenceProvider extends BaseMCWSPersistenceProvider
       if (error.status !== 404) {
         const userFolder = namespace.split(':')[0].split('-').pop();
         this.openmct.notifications.error(
-          `Unable to open ${userFolder} folder. Error: ${error.message ?? 'Unknown error'}. Open and close the folder to try again. If issue persists, check network connection and try again.`
+          `Unable to open ${userFolder} folder. Close and open the folder to try again. If issue persists, check network connection and try again.`
         );
 
         return {

--- a/src/persistence/MCWSPersistenceProvider.js
+++ b/src/persistence/MCWSPersistenceProvider.js
@@ -18,9 +18,8 @@ export default class MCWSPersistenceProvider extends BaseMCWSPersistenceProvider
       options.signal = abortSignal;
     }
 
-    const persistenceNamespace = await this.#getNamespace(namespace, options);
-
     try {
+      const persistenceNamespace = await this.#getNamespace(namespace, options);
       let result = await persistenceNamespace.opaqueFile(key).read();
 
       result = await this.#fromPersistableModel(result, identifier);

--- a/src/persistence/MCWSPersistenceProvider.js
+++ b/src/persistence/MCWSPersistenceProvider.js
@@ -29,11 +29,16 @@ export default class MCWSPersistenceProvider extends BaseMCWSPersistenceProvider
     } catch (error) {
       console.warn('MCWSPersistenceProvider:get', error);
 
-      return {
-        identifier,
-        type: 'unknown',
-        name: 'Error: ' + this.openmct.objects.makeKeyString(identifier)
-      };
+      // it's a network error, we don't want to create a new object
+      if (error.status !== 404) {
+        return {
+          identifier,
+          type: 'unknown',
+          name: 'Error: ' + this.openmct.objects.makeKeyString(identifier)
+        };
+      }
+
+      return;
     }
   }
 

--- a/src/persistence/MCWSPersistenceProvider.js
+++ b/src/persistence/MCWSPersistenceProvider.js
@@ -32,10 +32,7 @@ export default class MCWSPersistenceProvider extends BaseMCWSPersistenceProvider
       // so the old persistence interceptor isn't triggered erasing the object
       console.warn('MCWSPersistenceProvider:get', error);
 
-      return {
-        identifier,
-        name: 'Error Reading Object'
-      };
+      return {};
     }
   }
 

--- a/src/persistence/MCWSPersistenceProvider.js
+++ b/src/persistence/MCWSPersistenceProvider.js
@@ -29,7 +29,11 @@ export default class MCWSPersistenceProvider extends BaseMCWSPersistenceProvider
     } catch (error) {
       console.warn('MCWSPersistenceProvider:get', error);
 
-      return;
+      return {
+        identifier,
+        type: 'unknown',
+        name: 'Error: ' + this.openmct.objects.makeKeyString(identifier)
+      };
     }
   }
 

--- a/src/persistence/MCWSPersistenceProvider.js
+++ b/src/persistence/MCWSPersistenceProvider.js
@@ -27,9 +27,15 @@ export default class MCWSPersistenceProvider extends BaseMCWSPersistenceProvider
 
       return result;
     } catch (error) {
+      // we handle 404 errors and they don't propagate up to the user
+      // anything else we want to warn the user about and not return undefined
+      // so the old persistence interceptor isn't triggered erasing the object
       console.warn('MCWSPersistenceProvider:get', error);
 
-      return;
+      return {
+        identifier,
+        name: 'Error Reading Object'
+      };
     }
   }
 

--- a/src/persistence/MCWSPersistenceProvider.js
+++ b/src/persistence/MCWSPersistenceProvider.js
@@ -1,9 +1,6 @@
 import BaseMCWSPersistenceProvider from './BaseMCWSPersistenceProvider';
 import mcws from '../services/mcws/mcws';
 
-const MAX_RETRIES = 3;
-const INITIAL_RETRY_DELAY = 1000; // 1 second
-
 export default class MCWSPersistenceProvider extends BaseMCWSPersistenceProvider {
   /**
    * Read an existing object back from persistence.
@@ -22,38 +19,26 @@ export default class MCWSPersistenceProvider extends BaseMCWSPersistenceProvider
     }
 
     const persistenceNamespace = await this.#getNamespace(namespace, options);
-    let retryCount = 0;
 
-    while (retryCount <= MAX_RETRIES) {
-      try {
-        let result = await persistenceNamespace.opaqueFile(key).read();
-        result = await this.#fromPersistableModel(result, identifier);
-        return result;
-      } catch (error) {
-        console.warn(
-          `MCWSPersistenceProvider:get attempt ${retryCount + 1}/${MAX_RETRIES + 1}`,
-          error
-        );
+    try {
+      let result = await persistenceNamespace.opaqueFile(key).read();
 
-        // Don't retry 404s - they mean the object doesn't exist
-        if (error.status === 404) {
-          return;
-        }
+      result = await this.#fromPersistableModel(result, identifier);
 
-        // If we've hit max retries, return the error object
-        if (retryCount === MAX_RETRIES) {
-          return {
-            identifier,
-            type: 'unknown',
-            name: 'Error: ' + this.openmct.objects.makeKeyString(identifier)
-          };
-        }
+      return result;
+    } catch (error) {
+      console.warn('MCWSPersistenceProvider:get', error);
 
-        // Wait with exponential backoff before retrying
-        const delay = INITIAL_RETRY_DELAY * Math.pow(2, retryCount);
-        await new Promise((resolve) => setTimeout(resolve, delay));
-        retryCount++;
+      // it's a network error, we don't want to create a new object
+      if (error.status !== 404) {
+        return {
+          identifier,
+          type: 'unknown',
+          name: 'Error: ' + this.openmct.objects.makeKeyString(identifier)
+        };
       }
+
+      return;
     }
   }
 

--- a/src/persistence/MCWSPersistenceProvider.js
+++ b/src/persistence/MCWSPersistenceProvider.js
@@ -31,6 +31,10 @@ export default class MCWSPersistenceProvider extends BaseMCWSPersistenceProvider
 
       // it's a network error, we don't want to create a new object
       if (error.status !== 404) {
+        this.openmct.notify.error(
+          `Error: ${error.message ?? 'Unknown error'}. Check network connection and try again.`
+        );
+
         return {
           identifier,
           type: 'unknown',

--- a/src/persistence/MCWSPersistenceProvider.js
+++ b/src/persistence/MCWSPersistenceProvider.js
@@ -27,16 +27,9 @@ export default class MCWSPersistenceProvider extends BaseMCWSPersistenceProvider
 
       return result;
     } catch (error) {
-      // we handle 404 errors and they don't propagate up to the user
-      // anything else we want to warn the user about and not return undefined
-      // so the old persistence interceptor isn't triggered erasing the object
       console.warn('MCWSPersistenceProvider:get', error);
 
-      return {
-        identifier,
-        type: 'unknown',
-        name: 'Error: ' + this.openmct.objects.makeKeyString(identifier)
-      };
+      return;
     }
   }
 

--- a/src/persistence/MCWSPersistenceProvider.js
+++ b/src/persistence/MCWSPersistenceProvider.js
@@ -30,8 +30,9 @@ export default class MCWSPersistenceProvider extends BaseMCWSPersistenceProvider
 
       // it's a network error, we don't want to create a new object
       if (error.status !== 404) {
+        const userFolder = namespace.split(':')[0].split('-').pop();
         this.openmct.notifications.error(
-          `Error: ${error.message ?? 'Unknown error'}. Check network connection and try again.`
+          `Unable to open ${userFolder} folder. Error: ${error.message ?? 'Unknown error'}. Open and close the folder to try again. If issue persists, check network connection and try again.`
         );
 
         return {

--- a/src/persistence/MCWSPersistenceProvider.js
+++ b/src/persistence/MCWSPersistenceProvider.js
@@ -32,7 +32,11 @@ export default class MCWSPersistenceProvider extends BaseMCWSPersistenceProvider
       // so the old persistence interceptor isn't triggered erasing the object
       console.warn('MCWSPersistenceProvider:get', error);
 
-      return {};
+      return {
+        identifier,
+        type: 'unknown',
+        name: 'Error: ' + this.openmct.objects.makeKeyString(identifier)
+      };
     }
   }
 

--- a/src/persistence/MCWSPersistenceProvider.js
+++ b/src/persistence/MCWSPersistenceProvider.js
@@ -30,7 +30,7 @@ export default class MCWSPersistenceProvider extends BaseMCWSPersistenceProvider
 
       // it's a network error, we don't want to create a new object
       if (error.status !== 404) {
-        this.openmct.notify.error(
+        this.openmct.notifications.error(
           `Error: ${error.message ?? 'Unknown error'}. Check network connection and try again.`
         );
 

--- a/src/persistence/oldPersistenceFolderInterceptor.js
+++ b/src/persistence/oldPersistenceFolderInterceptor.js
@@ -33,8 +33,6 @@ export default async function oldPersistenceFolderInterceptor(
       return isMissing && isNotUserRoot && (isUserFolderIdentifier || isRootFolder);
     },
     invoke: (identifier, object) => {
-      console.log('oldPersistenceFolderInterceptor', identifier, object);
-      console.log('namespaces', namespaces);
       let userId = 'system';
       let namespaceDefinition;
 

--- a/src/persistence/oldPersistenceFolderInterceptor.js
+++ b/src/persistence/oldPersistenceFolderInterceptor.js
@@ -33,6 +33,8 @@ export default async function oldPersistenceFolderInterceptor(
       return isMissing && isNotUserRoot && (isUserFolderIdentifier || isRootFolder);
     },
     invoke: (identifier, object) => {
+      console.log('oldPersistenceFolderInterceptor', identifier, object);
+      console.log('namespaces', namespaces);
       let userId = 'system';
       let namespaceDefinition;
 

--- a/src/persistence/oldPersistenceFolderInterceptor.js
+++ b/src/persistence/oldPersistenceFolderInterceptor.js
@@ -36,6 +36,15 @@ export default async function oldPersistenceFolderInterceptor(
       let userId = 'system';
       let namespaceDefinition;
 
+      // if the object is unknown and the name is an error message,
+      // we don't want to create a new object, this is a network error
+      if (
+        object.type === 'unknown' &&
+        object.name === 'Error: ' + openmct.objects.makeKeyString(identifier)
+      ) {
+        return object;
+      }
+
       if (
         isUserNamespace(usersNamespace, userKeyRegex, identifier) &&
         !identifier.namespace.includes('shared')

--- a/src/persistence/oldPersistenceFolderInterceptor.js
+++ b/src/persistence/oldPersistenceFolderInterceptor.js
@@ -38,10 +38,7 @@ export default async function oldPersistenceFolderInterceptor(
 
       // if the object is unknown and the name is an error message,
       // we don't want to create a new object, this is a network error
-      if (
-        object.type === 'unknown' &&
-        object.name === 'Error: ' + openmct.objects.makeKeyString(identifier)
-      ) {
+      if (object.networkError === true) {
         return object;
       }
 

--- a/src/persistence/oldPersistenceFolderInterceptor.js
+++ b/src/persistence/oldPersistenceFolderInterceptor.js
@@ -36,8 +36,7 @@ export default async function oldPersistenceFolderInterceptor(
       let userId = 'system';
       let namespaceDefinition;
 
-      // if the object is unknown and the name is an error message,
-      // we don't want to create a new object, this is a network error
+      // if the object is a network error object, we don't want to create a new object
       if (object.networkError === true) {
         return object;
       }


### PR DESCRIPTION
closes #240 

If there's an error getting an object that is NOT a `404`, then we return an error object, similar to how we return a missing object for missing... objects (in our case for user folders a `404` means we create the root object: https://github.com/NASA-AMMOS/openmct-mcws/blob/3f58be75b257bc6c1ce2f31d1feb06b6f735ccda/src/persistence/BaseMCWSPersistenceProvider.js#L178
This addition of returning the error object, allows us to not try to save a missing object caused from a network error (no internet for example) in the case it's from an older persistence store that had folders on the backend, but no root object : https://github.com/NASA-AMMOS/openmct-mcws/blob/3f58be75b257bc6c1ce2f31d1feb06b6f735ccda/src/persistence/oldPersistenceFolderInterceptor.js#L52

Also added a retry loop. It will retry 3 times to get the object in 2, 4 and 8 second intervals at which point it will return the error object if there is still a network error.