### PR TITLE
Enable Additional Plugins

### DIFF
--- a/config.js
+++ b/config.js
@@ -403,19 +403,19 @@
         enabled: true
       },
       BarChart: {
-        enabled: true
+        enabled: false
       },
       ScatterPlot: {
-        enabled: true
+        enabled: false
       },
       Timeline: {
-        enabled: true
+        enabled: false
       },
       Timelist: {
-        enabled: true
+        enabled: false
       },
       PlanLayout: {
-        enabled: true,
+        enabled: false,
         configuration: [
           {
             name: 'Gantt Chart',

--- a/config.js
+++ b/config.js
@@ -626,8 +626,8 @@
      * Developer Settings-- do not modify these unless you know what
      * they do!
      */
-    proxyUrl: 'http://localhost:8080/',
-    useDeveloperStorage: true,
+    // proxyUrl: 'http://localhost:8080/',
+    // useDeveloperStorage: true,
     assetPath: 'node_modules/openmct/dist'
   };
 

--- a/config.js
+++ b/config.js
@@ -374,19 +374,23 @@
      * Plugin Support 
      * Example configuration:
      * plugins: {        
-        // Simple enable
+        // Simple enable:
+        // openmct.plugins.anotherPlugin()
         anotherPlugin: {
           enabled: true
         },
-        // Enable with options
-        configuredPlugin: {
+        // Enable with options:
+        // openmct.plugins.ConfiguredPlugin({setting1: 'value1', setting2: 'value2'}, 1000)
+        // 1000 is passed as the second argument to the plugin constructor
+        ConfiguredPlugin: {
           enabled: true,
           // these are passed as arguments to the plugin constructor
           configuration: [
             {
               setting1: 'value1',
               setting2: 'value2'
-            }
+            },
+            1000
           ]
         }
       }
@@ -399,7 +403,26 @@
         enabled: true
       },
       BarChart: {
-        enabled: false
+        enabled: true
+      },
+      ScatterPlot: {
+        enabled: true
+      },
+      Timeline: {
+        enabled: true
+      },
+      Timelist: {
+        enabled: true
+      },
+      PlanLayout: {
+        enabled: true,
+        configuration: [
+          {
+            name: 'Gantt Chart',
+            creatable: true,
+            namespace: '' // namespace to use for the activity state object
+          }
+        ]
       }
     },
 
@@ -603,8 +626,8 @@
      * Developer Settings-- do not modify these unless you know what
      * they do!
      */
-    // proxyUrl: 'http://localhost:8080/',
-    // useDeveloperStorage: true,
+    proxyUrl: 'http://localhost:8080/',
+    useDeveloperStorage: true,
     assetPath: 'node_modules/openmct/dist'
   };
 

--- a/loader.js
+++ b/loader.js
@@ -29,7 +29,7 @@ define([
   IdentityProvider,
   MCWSPersistenceProviderPlugin
 ) {
-  const ALLOWED_OPTIONAL_PLUGINS = ['BarChart'];
+  const ALLOWED_OPTIONAL_PLUGINS = ['BarChart', 'ScatterPlot', 'Timeline', 'Timelist', 'PlanLayout'];
 
   function loader(config) {
     let persistenceLoaded;
@@ -145,8 +145,8 @@ define([
       }
 
       pluginsToInstall.forEach(([plugin, pluginConfig]) => {
-        const { configuration = [] } = pluginConfig;
-
+        const configuration = pluginConfig.configuration ?? [];
+        console.log(plugin, configuration);
         openmct.install(openmct.plugins[plugin](...configuration));
       });
     }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "mini-css-extract-plugin": "2.7.6",
     "moment": "2.30.1",
     "node-bourbon": "^4.2.3",
-    "openmct": "github:nasa/openmct#omm-release/5.4.0",
+    "openmct": "github:nasa/openmct#omm-r5.4.0-rc1",
     "prettier": "3.4.2",
     "printj": "1.3.1",
     "raw-loader": "^0.5.1",


### PR DESCRIPTION
closes: #218 

This change adds new plugins to the config to be enabled from core Open MCT. They are: Time Strip, Time List, Plan, Scatter Plot.

Also, enabled the ability to add any core plugins (tested or not on our end), with a warning in the console that the plugin has not been tested.