### PR TITLE
369 fix local dev

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -233,7 +233,9 @@ export default function openmctMCWSPlugin(options) {
 
     openmct.user.setProvider(new IdentityProvider(openmct));
 
-    openmct.install(MCWSPersistenceProviderPlugin(config.namespaces));
+    if (!config.useDeveloperStorage) {
+      openmct.install(MCWSPersistenceProviderPlugin(config.namespaces));
+    }
 
     openmct.branding({ aboutHtml: insertBuildInfo(AboutTemplate) });
 


### PR DESCRIPTION
Fixes #369

Suppresses MCWS persistence providers if `useDeveloperStorage` is true. This restores the ability to test locally without an MCWS persistence server.