### PR TITLE
Defined namespaces and dev persistance by default

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -162,6 +162,8 @@ export default function openmctMCWSPlugin(options) {
       // Attempt to define a reasonable default for developer storage that supports Open MCT build tool
       if (config.mcwsUrl === undefined || config.mcwsUrl.trim().length === 0) {
         config.useDeveloperStorage = true;
+      } else {
+        config.useDeveloperStorage = false;
       }
     }
 


### PR DESCRIPTION
Closes https://github.com/NASA-AMMOS/openmct-mcws/issues/371

* Defines default namespaces
* Defaults to developer persistence mode. This will only apply if installed without any other configuration.