### PR TITLE
Cherry Picks`2c6fce0` into `v5.3.2` to fix evr streaming regression

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmct-mcws",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "description": "Open MCT for MCWS",
   "devDependencies": {
     "@braintree/sanitize-url": "6.0.4",

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>gov.nasa.arc.wtd</groupId>
     <artifactId>openmct-client</artifactId>
     <name>Open MCT for MCWS Client</name>
-    <version>5.3.1</version>
+    <version>5.3.2</version>
     <packaging>war</packaging>
 
     <properties>

--- a/src/realtime/MCWSEVRLevelStreamProvider.js
+++ b/src/realtime/MCWSEVRLevelStreamProvider.js
@@ -11,7 +11,7 @@ class MCWSEVRLevelStreamProvider extends MCWSStreamProvider {
      * @returns {String} The URL to use for streaming
      */
     getUrl(domainObject) {
-        if (domainObject.telemetry?.evrStreamUrl) {
+        if (domainObject.telemetry?.evrStreamUrl && domainObject.telemetry?.level) {
             return domainObject.telemetry.evrStreamUrl;
         }
     }

--- a/src/realtime/MCWSEVRStreamProvider.js
+++ b/src/realtime/MCWSEVRStreamProvider.js
@@ -11,7 +11,7 @@ class MCWSEVRStreamProvider extends MCWSStreamProvider {
      * @returns {String} The URL to use for streaming
      */
     getUrl(domainObject) {
-        if (domainObject.telemetry && !domainObject.telemetry.level) {
+        if (domainObject.telemetry?.evrStreamUrl && !domainObject.telemetry?.level) {
             return domainObject.telemetry.evrStreamUrl;
         }
     }


### PR DESCRIPTION
Patches #388 in `v5.3.2`

2c6fce0587bbb97d74f0f582858f9b405fcfdad7 was back merged after `v5.3.1` into and closes #388 in `main`.