### PR TITLE
393 fix cached dataset load

### DIFF
--- a/src/realtimeSessions/components/RealtimeSessionIndicator.vue
+++ b/src/realtimeSessions/components/RealtimeSessionIndicator.vue
@@ -73,7 +73,7 @@ export default {
         this.activeSession = this.sessionService.getActiveTopicOrSession();
         this.stopListening = this.sessionService.listen(this.onActiveSessionChange);
 
-        this.pollForSessions();
+        this.pollForSessions(true);
     },
     beforeUnmount() {
         this.stopListening?.();
@@ -84,10 +84,10 @@ export default {
         }
     },
     methods: {
-        pollForSessions() {
+        pollForSessions(resolveCachedDatasets = false ) {
             if (!this.activeSession) {
                 this.sessionService
-                    .getTopicsWithSessions()
+                    .getTopicsWithSessions( resolveCachedDatasets )
                     .then(topics => {
                         this.hasTopics = topics.length > 0;
                     });

--- a/src/services/session/SessionService.js
+++ b/src/services/session/SessionService.js
@@ -243,13 +243,49 @@ class SessionService {
      *
      * @returns {Promise.<Topic[]>}
      */
-    async getTopicsWithSessions() {
+    async getTopicsWithSessions(resolveCachedDatasets = false) {
         if (this.realtimeSessionConfig.disable) {
             return Promise.resolve([]);
         }
+        let datasets = [];
+        // Need to wait for MIOs to load for the cached datasets to return.
+        const cachedDatasets = new Promise((resolve) => {
+        // Check once a second
+        const pollInterval = 1000;
+        let currentLength = 0;
+        let maxIterations = 15;
+        let currentIteration = 0;
+        const checkDatasets = () => {
+            const result = Object.values(this.getDatasets());
+            if (result.length > 0) {
+                // Success - we have data
+                if (currentLength !=0 ) {
+                    if (result.length == currentLength){
+                        resolve(result);
+                    }
+                } else {
+                    currentLength = result.length;
+                    setTimeout(checkDatasets, pollInterval);
 
-        const datasets = Object.values(this.getDatasets());
-        const validUrls = datasets.map(dataset => dataset.options.sessionLADUrl).filter(url => url);
+                }
+                
+            } else {
+                // Check if we've hit our 15 seconds give up interval
+                if (currentIteration > maxIterations) {
+                    resolve([]);
+                }
+                currentIteration++;
+                setTimeout(checkDatasets, pollInterval);
+            }
+        };
+        checkDatasets(); // Start polling
+        });
+        if (resolveCachedDatasets) {
+            datasets = await cachedDatasets;
+        } else {
+            datasets = Object.values(this.getDatasets());
+        }
+        const validUrls = datasets.map(datasets => datasets.options.sessionLADUrl).filter(url => url);
         const sessionLADUrls = validUrls.reduce((uniqueUrls, url) => {
             return uniqueUrls.includes(url) ? uniqueUrls : [...uniqueUrls, url];
         }, []);

--- a/src/services/session/SessionService.js
+++ b/src/services/session/SessionService.js
@@ -250,53 +250,53 @@ class SessionService {
         let datasets = [];
         // Need to wait for MIOs to load for the cached datasets to return.
         const cachedDatasets = new Promise((resolve) => {
-        // Check once a second
-        const pollInterval = 1000;
-        let currentLength = 0;
-        let maxIterations = 15;
-        let currentIteration = 0;
-        const checkDatasets = () => {
-            const result = Object.values(this.getDatasets());
+            // Check once a second
+            const pollInterval = 1000;
+            let currentLength = 0;
+            let maxIterations = 15;
+            let currentIteration = 0;
+            const checkDatasets = () => {
+                const result = Object.values(this.getDatasets());
 
-            // no datasets
-            if (result.length === 0) {
-                // maxed out iterations, give up and resolve with empty array
-                if (currentIteration > maxIterations) {
-                    resolve([]);
-                    return;
-                }
-                currentIteration++;
-                setTimeout(checkDatasets, pollInterval);
-            } else { // we have datasets
-                // first time we have datasets
-                if (currentLength === 0) {
-                    currentLength = result.length;
+                // no datasets
+                if (result.length === 0) {
+                    // maxed out iterations, give up and resolve with empty array
+                    if (currentIteration > maxIterations) {
+                        resolve([]);
+                        return;
+                    }
+                    currentIteration++;
                     setTimeout(checkDatasets, pollInterval);
-                } else { // we've already seen some datasets, check for stability
-                    if (result.length === currentLength) { // we have stability, resolve
-                        resolve(result);
-                    } else { // datasets still loading, wait for stability
+                } else { // we have datasets
+                    // first time we have datasets
+                    if (currentLength === 0) {
                         currentLength = result.length;
                         setTimeout(checkDatasets, pollInterval);
-                    } 
+                    } else { // we've already seen some datasets, check for stability
+                        if (result.length === currentLength) { // we have stability, resolve
+                            resolve(result);
+                        } else { // datasets still loading, wait for stability
+                            currentLength = result.length;
+                            setTimeout(checkDatasets, pollInterval);
+                        } 
+                    }
                 }
-            }
-        };
-        checkDatasets(); // Start polling
-    });
-    if (resolveCachedDatasets) {
-        datasets = await cachedDatasets;
-    } else {
-        datasets = Object.values(this.getDatasets());
-    }
-    const validUrls = datasets.map((dataset) => dataset.options.sessionLADUrl).filter(Boolean);
-    const sessionLADUrls = validUrls.reduce((uniqueUrls, url) => {
-        return uniqueUrls.includes(url) ? uniqueUrls : [...uniqueUrls, url];
-    }, []);
-    const topicsWithSessions = await Promise.all(sessionLADUrls.map(url => this.getActiveSessions(url)));
+            };
+            checkDatasets(); // Start polling
+        });
+        if (resolveCachedDatasets) {
+            datasets = await cachedDatasets;
+        } else {
+            datasets = Object.values(this.getDatasets());
+        }
+        const validUrls = datasets.map((dataset) => dataset.options.sessionLADUrl).filter(Boolean);
+        const sessionLADUrls = validUrls.reduce((uniqueUrls, url) => {
+            return uniqueUrls.includes(url) ? uniqueUrls : [...uniqueUrls, url];
+        }, []);
+        const topicsWithSessions = await Promise.all(sessionLADUrls.map(url => this.getActiveSessions(url)));
 
-    return topicsWithSessions.flat();
-  };
+        return topicsWithSessions.flat();
+    };
 
     makeMCWSFilters(filters) {
         if (!filters) {

--- a/src/services/session/SessionService.js
+++ b/src/services/session/SessionService.js
@@ -215,28 +215,28 @@ class SessionService {
             this.showCamTimeoutError(error);
         }
 
-    const sessionsByTopic = {};
-    sessions.forEach((session) => {
-      if (sessionsByTopic[session.topic] === undefined) {
-        sessionsByTopic[session.topic] = [];
-      }
+        const sessionsByTopic = {};
+        sessions.forEach((session) => {
+            if (sessionsByTopic[session.topic] === undefined) {
+                sessionsByTopic[session.topic] = [];
+            }
 
-      sessionsByTopic[session.topic].push(session);
-    });
+            sessionsByTopic[session.topic].push(session);
+        });
 
-    // for each topic, remove 'number' property from the first session object in the topic as the base topic object
-    const topics = Object.keys(sessionsByTopic).map((topic) => {
-      const topicObj = { ...sessionsByTopic[topic][0] };
-      delete topicObj.number;
+        // for each topic, remove 'number' property from the first session object in the topic as the base topic object
+        const topics = Object.keys(sessionsByTopic).map((topic) => {
+            const topicObj = { ...sessionsByTopic[topic][0] };
+            delete topicObj.number;
 
-      // filter out sessions without a 'number' property and add them to the topic object sessions
-      topicObj.sessions = sessionsByTopic[topic].filter((session) => session.number);
+            // filter out sessions without a 'number' property and add them to the topic object sessions
+            topicObj.sessions = sessionsByTopic[topic].filter((session) => session.number);
 
-      return topicObj;
-    });
+            return topicObj;
+        });
 
-    return topics;
-  }
+        return topics;
+    }
 
   /**
    * Get available topics with sessions.
@@ -244,47 +244,45 @@ class SessionService {
    * @returns {Promise.<Topic[]>}
    */
   async getTopicsWithSessions(resolveCachedDatasets = false) {
-    if (this.realtimeSessionConfig.disable) {
-      return Promise.resolve([]);
-    }
-    let datasets = [];
-    // Need to wait for MIOs to load for the cached datasets to return.
-    const cachedDatasets = new Promise((resolve) => {
-      // Check once a second
-      const pollInterval = 1000;
-      let currentLength = 0;
-      let maxIterations = 15;
-      let currentIteration = 0;
-      const checkDatasets = () => {
-        const result = Object.values(this.getDatasets());
-
-        // no datasets
-        if (result.length === 0) {
-          // maxed out iterations, give up and resolve with empty array
-          if (currentIteration > maxIterations) {
-            resolve([]);
-
-            return;
-          }
-
-          currentIteration++;
-          setTimeout(checkDatasets, pollInterval);
-        } else { // we have datasets
-          // first time we have datasets
-          if (currentLength === 0) {
-            currentLength = result.length;
-            setTimeout(checkDatasets, pollInterval);
-          } else { // we've already seen some datasets, check for stability
-            if (result.length === currentLength) { // we have stability, resolve
-              resolve(result);
-            } else { // datasets still loading, wait for stability
-              currentLength = result.length;
-              setTimeout(checkDatasets, pollInterval);
-            } 
-          }
+        if (this.realtimeSessionConfig.disable) {
+        return Promise.resolve([]);
         }
-      };
-      checkDatasets(); // Start polling
+        let datasets = [];
+        // Need to wait for MIOs to load for the cached datasets to return.
+        const cachedDatasets = new Promise((resolve) => {
+        // Check once a second
+        const pollInterval = 1000;
+        let currentLength = 0;
+        let maxIterations = 15;
+        let currentIteration = 0;
+        const checkDatasets = () => {
+            const result = Object.values(this.getDatasets());
+
+            // no datasets
+            if (result.length === 0) {
+                // maxed out iterations, give up and resolve with empty array
+                if (currentIteration > maxIterations) {
+                    resolve([]);
+                    return;
+                }
+                currentIteration++;
+                setTimeout(checkDatasets, pollInterval);
+            } else { // we have datasets
+                // first time we have datasets
+                if (currentLength === 0) {
+                    currentLength = result.length;
+                    setTimeout(checkDatasets, pollInterval);
+                } else { // we've already seen some datasets, check for stability
+                    if (result.length === currentLength) { // we have stability, resolve
+                        resolve(result);
+                    } else { // datasets still loading, wait for stability
+                        currentLength = result.length;
+                        setTimeout(checkDatasets, pollInterval);
+                    } 
+                }
+            }
+        };
+        checkDatasets(); // Start polling
     });
     if (resolveCachedDatasets) {
         datasets = await cachedDatasets;
@@ -293,7 +291,7 @@ class SessionService {
     }
     const validUrls = datasets.map((dataset) => dataset.options.sessionLADUrl).filter(Boolean);
     const sessionLADUrls = validUrls.reduce((uniqueUrls, url) => {
-      return uniqueUrls.includes(url) ? uniqueUrls : [...uniqueUrls, url];
+        return uniqueUrls.includes(url) ? uniqueUrls : [...uniqueUrls, url];
     }, []);
     const topicsWithSessions = await Promise.all(sessionLADUrls.map(url => this.getActiveSessions(url)));
 

--- a/src/services/session/SessionService.js
+++ b/src/services/session/SessionService.js
@@ -238,14 +238,14 @@ class SessionService {
         return topics;
     }
 
-  /**
-   * Get available topics with sessions.
-   *
-   * @returns {Promise.<Topic[]>}
-   */
-  async getTopicsWithSessions(resolveCachedDatasets = false) {
+    /**
+     * Get available topics with sessions.
+     *
+     * @returns {Promise.<Topic[]>}
+     */
+    async getTopicsWithSessions(resolveCachedDatasets = false) {
         if (this.realtimeSessionConfig.disable) {
-        return Promise.resolve([]);
+            return Promise.resolve([]);
         }
         let datasets = [];
         // Need to wait for MIOs to load for the cached datasets to return.

--- a/src/services/session/SessionService.js
+++ b/src/services/session/SessionService.js
@@ -215,84 +215,90 @@ class SessionService {
             this.showCamTimeoutError(error);
         }
 
-        const sessionsByTopic = {};
-        sessions.forEach((session) => {
-            if (sessionsByTopic[session.topic] === undefined) {
-                sessionsByTopic[session.topic] = [];
-            }
+    const sessionsByTopic = {};
+    sessions.forEach((session) => {
+      if (sessionsByTopic[session.topic] === undefined) {
+        sessionsByTopic[session.topic] = [];
+      }
 
-            sessionsByTopic[session.topic].push(session);
-        });
+      sessionsByTopic[session.topic].push(session);
+    });
 
-        // for each topic, remove 'number' property from the first session object in the topic as the base topic object
-        const topics = Object.keys(sessionsByTopic).map((topic) => {
-            const topicObj = { ...sessionsByTopic[topic][0] };
-            delete topicObj.number;
+    // for each topic, remove 'number' property from the first session object in the topic as the base topic object
+    const topics = Object.keys(sessionsByTopic).map((topic) => {
+      const topicObj = { ...sessionsByTopic[topic][0] };
+      delete topicObj.number;
 
-            // filter out sessions without a 'number' property and add them to the topic object sessions
-            topicObj.sessions = sessionsByTopic[topic].filter((session) => session.number);
+      // filter out sessions without a 'number' property and add them to the topic object sessions
+      topicObj.sessions = sessionsByTopic[topic].filter((session) => session.number);
 
-            return topicObj;
-        });
+      return topicObj;
+    });
 
-        return topics;
+    return topics;
+  }
+
+  /**
+   * Get available topics with sessions.
+   *
+   * @returns {Promise.<Topic[]>}
+   */
+  async getTopicsWithSessions(resolveCachedDatasets = false) {
+    if (this.realtimeSessionConfig.disable) {
+      return Promise.resolve([]);
     }
+    let datasets = [];
+    // Need to wait for MIOs to load for the cached datasets to return.
+    const cachedDatasets = new Promise((resolve) => {
+      // Check once a second
+      const pollInterval = 1000;
+      let currentLength = 0;
+      let maxIterations = 15;
+      let currentIteration = 0;
+      const checkDatasets = () => {
+        const result = Object.values(this.getDatasets());
 
-    /**
-     * Get available topics with sessions.
-     *
-     * @returns {Promise.<Topic[]>}
-     */
-    async getTopicsWithSessions(resolveCachedDatasets = false) {
-        if (this.realtimeSessionConfig.disable) {
-            return Promise.resolve([]);
+        // no datasets
+        if (result.length === 0) {
+          // maxed out iterations, give up and resolve with empty array
+          if (currentIteration > maxIterations) {
+            resolve([]);
+
+            return;
+          }
+
+          currentIteration++;
+          setTimeout(checkDatasets, pollInterval);
+        } else { // we have datasets
+          // first time we have datasets
+          if (currentLength === 0) {
+            currentLength = result.length;
+            setTimeout(checkDatasets, pollInterval);
+          } else { // we've already seen some datasets, check for stability
+            if (result.length === currentLength) { // we have stability, resolve
+              resolve(result);
+            } else { // datasets still loading, wait for stability
+              currentLength = result.length;
+              setTimeout(checkDatasets, pollInterval);
+            } 
+          }
         }
-        let datasets = [];
-        // Need to wait for MIOs to load for the cached datasets to return.
-        const cachedDatasets = new Promise((resolve) => {
-        // Check once a second
-        const pollInterval = 1000;
-        let currentLength = 0;
-        let maxIterations = 15;
-        let currentIteration = 0;
-        const checkDatasets = () => {
-            const result = Object.values(this.getDatasets());
-            if (result.length > 0) {
-                // Success - we have data
-                if (currentLength !=0 ) {
-                    if (result.length == currentLength){
-                        resolve(result);
-                    }
-                } else {
-                    currentLength = result.length;
-                    setTimeout(checkDatasets, pollInterval);
+      };
+      checkDatasets(); // Start polling
+    });
+    if (resolveCachedDatasets) {
+        datasets = await cachedDatasets;
+    } else {
+        datasets = Object.values(this.getDatasets());
+    }
+    const validUrls = datasets.map((dataset) => dataset.options.sessionLADUrl).filter(Boolean);
+    const sessionLADUrls = validUrls.reduce((uniqueUrls, url) => {
+      return uniqueUrls.includes(url) ? uniqueUrls : [...uniqueUrls, url];
+    }, []);
+    const topicsWithSessions = await Promise.all(sessionLADUrls.map(url => this.getActiveSessions(url)));
 
-                }
-                
-            } else {
-                // Check if we've hit our 15 seconds give up interval
-                if (currentIteration > maxIterations) {
-                    resolve([]);
-                }
-                currentIteration++;
-                setTimeout(checkDatasets, pollInterval);
-            }
-        };
-        checkDatasets(); // Start polling
-        });
-        if (resolveCachedDatasets) {
-            datasets = await cachedDatasets;
-        } else {
-            datasets = Object.values(this.getDatasets());
-        }
-        const validUrls = datasets.map(datasets => datasets.options.sessionLADUrl).filter(url => url);
-        const sessionLADUrls = validUrls.reduce((uniqueUrls, url) => {
-            return uniqueUrls.includes(url) ? uniqueUrls : [...uniqueUrls, url];
-        }, []);
-        const topicsWithSessions = await Promise.all(sessionLADUrls.map(url => this.getActiveSessions(url)));
-
-        return topicsWithSessions.flat();
-    };
+    return topicsWithSessions.flat();
+  };
 
     makeMCWSFilters(filters) {
         if (!filters) {


### PR DESCRIPTION
Implements https://github.com/NASA-AMMOS/openmct-mcws/issues/393

Fixes an issue in getTopicsWithSessions interaction with persistence storage that caused a minimum of 15s delay before realtime sessions were stored. 

old behavior: getTopicsWithSessions would check the dataset cache with getDatasets. The problem is that this is a race condition with MIO loads, as when it runs there are almost never any datasets loaded yet. 

new behavior: 
1. Added an async function that will check the getDatasets cache every 1 second for up to 15 seconds before returning an empty set. If a new dataset is found during this iteraction, will check for another dataset 1s later in case MIOS are still loading. 
2. Added a new flag to getTopicsWithSessions which will toggle between the new behavior and the old behavior. This preserves the instant response on user interaction with the realtime session selection UI.