### PR TITLE
354 fix redos vulnerable regex patterns

### DIFF
--- a/src/persistence/BaseMCWSPersistenceProvider.js
+++ b/src/persistence/BaseMCWSPersistenceProvider.js
@@ -1,7 +1,7 @@
 import mcws from '../services/mcws/mcws.js';
 import { createModelFromNamespaceDefinitionWithPersisted, interpolateUsername } from './utils.js';
 
-const USERNAME_FROM_PATH_REGEX = new RegExp('.*/(.*?)$');
+const USERNAME_FROM_PATH_REGEX = new RegExp('([^/]*)$');
 
 /**
  * An object defining a MCWS namespace.  Provides a unique identifier for a

--- a/src/services/dataset/Dataset.js
+++ b/src/services/dataset/Dataset.js
@@ -230,7 +230,7 @@ class Dataset {
   }
 
   omitsDictionaryVersion(url) {
-    return /\/.*Dictionary\/?$/.test(url);
+    return /\/[^/]*Dictionary\/?$/.test(url);
   }
 
   /**


### PR DESCRIPTION
Fixes: https://github.com/NASA-AMMOS/openmct-mcws/issues/354

Replaces two regex patterns that were vulnerable to catastrophic backtracking (ReDoS) with equivalent patterns using negated character classes.

- `BaseMCWSPersistenceProvider.js`: `.*/(.*?)$` replaced with `([^/]*)$` -- eliminates backtracking on the greedy `.*` while still capturing the last path segment.
- `Dataset.js`: `\/.*Dictionary\/?$` replaced with `\/[^/]*Dictionary\/?$` -- constrains the wildcard to a single path segment, which is all it ever needs to match.

Both patterns produce identical results for all valid inputs.