### PR TITLE
393 fix cached dataset load

### DIFF
--- a/src/realtimeSessions/components/RealtimeSessionIndicator.vue
+++ b/src/realtimeSessions/components/RealtimeSessionIndicator.vue
@@ -62,15 +62,15 @@ export default {
     this.activeSession = this.sessionService.getActiveTopicOrSession();
     this.stopListening = this.sessionService.listen(this.onActiveSessionChange);
 
-    this.pollForSessions();
+    this.pollForSessions(true);
   },
   beforeUnmount() {
     this.stopListening?.();
   },
   methods: {
-    pollForSessions() {
+    pollForSessions(resolveCachedDatasets = false ) {
       if (!this.activeSession) {
-        this.sessionService.getTopicsWithSessions().then((topics) => {
+        this.sessionService.getTopicsWithSessions(resolveCachedDatasets).then((topics) => {
           this.hasTopics = topics.length > 0;
         });
       }

--- a/src/realtimeSessions/components/RealtimeSessionIndicator.vue
+++ b/src/realtimeSessions/components/RealtimeSessionIndicator.vue
@@ -68,7 +68,7 @@ export default {
     this.stopListening?.();
   },
   methods: {
-    pollForSessions(resolveCachedDatasets = false ) {
+    pollForSessions(resolveCachedDatasets = false) {
       if (!this.activeSession) {
         this.sessionService.getTopicsWithSessions(resolveCachedDatasets).then((topics) => {
           this.hasTopics = topics.length > 0;

--- a/src/services/session/SessionService.js
+++ b/src/services/session/SessionService.js
@@ -259,25 +259,34 @@ class SessionService {
 
       const checkDatasets = () => {
         const result = Object.values(this.getDatasets());
-        if (result.length > 0) {
-          // Success - we have data
-          if (currentLength != 0) {
-            if (result.length == currentLength) {
-              resolve(result);
-            }
-          } else {
-            currentLength = result.length;
-            setTimeout(checkDatasets, pollInterval);
-          }
-        } else {
-          // Check if we've hit our 15 seconds give up interval
+
+        // no datasets
+        if (result.length === 0) {
+          // maxed out iterations, give up and resolve with empty array
           if (currentIteration > maxIterations) {
             resolve([]);
+
+            return;
           }
+
           currentIteration++;
           setTimeout(checkDatasets, pollInterval);
+        } else { // we have datasets
+          // first time we have datasets
+          if (currentLength === 0) {
+            currentLength = result.length;
+            setTimeout(checkDatasets, pollInterval);
+          } else { // we've already seen some datasets, check for stability
+            if (result.length === currentLength) { // we have stability, resolve
+              resolve(result);
+            } else { // datasets still loading, wait for stability
+              currentLength = result.length;
+              setTimeout(checkDatasets, pollInterval);
+            } 
+          }
         }
       };
+
       checkDatasets(); // Start polling
     });
 
@@ -288,8 +297,8 @@ class SessionService {
     }
 
     const validUrls = datasets
-      .map((datasets) => datasets.options.sessionLADUrl)
-      .filter((url) => url);
+      .map((dataset) => dataset.options.sessionLADUrl)
+      .filter(Boolean);
     const sessionLADUrls = validUrls.reduce((uniqueUrls, url) => {
       return uniqueUrls.includes(url) ? uniqueUrls : [...uniqueUrls, url];
     }, []);

--- a/src/services/session/SessionService.js
+++ b/src/services/session/SessionService.js
@@ -243,13 +243,53 @@ class SessionService {
    *
    * @returns {Promise.<Topic[]>}
    */
-  async getTopicsWithSessions() {
+  async getTopicsWithSessions(resolveCachedDatasets = false) {
     if (this.realtimeSessionConfig.disable) {
       return Promise.resolve([]);
     }
 
-    const datasets = Object.values(this.getDatasets());
-    const validUrls = datasets.map((dataset) => dataset.options.sessionLADUrl).filter((url) => url);
+    let datasets = [];
+    // Need to wait for MIOs to load for the cached datasets to return.
+    const cachedDatasets = new Promise((resolve) => {
+      // Check once a second
+      const pollInterval = 1000;
+      let currentLength = 0;
+      let maxIterations = 15;
+      let currentIteration = 0;
+
+      const checkDatasets = () => {
+        const result = Object.values(this.getDatasets());
+        if (result.length > 0) {
+          // Success - we have data
+          if (currentLength != 0) {
+            if (result.length == currentLength) {
+              resolve(result);
+            }
+          } else {
+            currentLength = result.length;
+            setTimeout(checkDatasets, pollInterval);
+          }
+        } else {
+          // Check if we've hit our 15 seconds give up interval
+          if (currentIteration > maxIterations) {
+            resolve([]);
+          }
+          currentIteration++;
+          setTimeout(checkDatasets, pollInterval);
+        }
+      };
+      checkDatasets(); // Start polling
+    });
+
+    if (resolveCachedDatasets) {
+      datasets = await cachedDatasets;
+    } else {
+      datasets = Object.values(this.getDatasets());
+    }
+
+    const validUrls = datasets
+      .map((datasets) => datasets.options.sessionLADUrl)
+      .filter((url) => url);
     const sessionLADUrls = validUrls.reduce((uniqueUrls, url) => {
       return uniqueUrls.includes(url) ? uniqueUrls : [...uniqueUrls, url];
     }, []);


### PR DESCRIPTION
fixes: https://github.com/NASA-AMMOS/openmct-mcws/issues/393

Fixes an issue in getTopicsWithSessions interaction with persistence storage that caused a minimum of 15s delay before realtime sessions were stored. 

old behavior: getTopicsWithSessions would check the dataset cache with getDatasets. The problem is that this is a race condition with MIO loads, as when it runs there are almost never any datasets loaded yet. 

new behavior: 
1. Added an async function that will check the getDatasets cache every 1 second for up to 15 seconds before returning an empty set. If a new dataset is found during this iteraction, will check for another dataset 1s later in case MIOS are still loading. 
2. Added a new flag to getTopicsWithSessions which will toggle between the new behavior and the old behavior. This preserves the instant response on user interaction with the realtime session selection UI.