### PR TITLE
343 fix enum alarm state for Main Branch

### DIFF
--- a/src/channelLimits/ChannelLimitsProvider.js
+++ b/src/channelLimits/ChannelLimitsProvider.js
@@ -37,7 +37,7 @@ export default class ChannelLimitsProvider {
       }
 
       // enum alarms are dn alarms
-      alarmKey.replace('enum_', 'dn_');
+      alarmKey = alarmKey.replace('enum_', 'dn_');
 
       return alarmKey;
     }


### PR DESCRIPTION
Fixes the enumeration implementation in ChannelLimitsProvider to work for enum alarm states. 

Fixes https://github.com/NASA-AMMOS/openmct-mcws/issues/343