### PR TITLE
Scrub MCWS user ID of invalid namespace characters

### DIFF
--- a/src/persistence/BaseMCWSPersistenceProvider.js
+++ b/src/persistence/BaseMCWSPersistenceProvider.js
@@ -117,7 +117,7 @@ export default class BaseMCWSPersistenceProvider {
 
     const user = await this.openmct.user.getCurrentUser();
     const containedNamespaces = await this.getNamespacesFromMCWS(namespaceDefinition);
-    const userNamespace = interpolateUsername(user.id, user.name, namespaceTemplate);
+    const userNamespace = interpolateUsername(namespaceTemplate, user.id, user.name);
     const existingUserNamespace = containedNamespaces.find(
       (namespace) => namespace.url === userNamespace.url
     );
@@ -131,7 +131,7 @@ export default class BaseMCWSPersistenceProvider {
 
     containedNamespaces.unshift(userNamespace);
 
-    await this.createIfMissing(user.id, userNamespace);
+    await this.createIfMissing(userNamespace, user.id);
 
     return containedNamespaces;
   }
@@ -150,7 +150,7 @@ export default class BaseMCWSPersistenceProvider {
     const templateObject = namespaceDefinition.childTemplate;
     const userNamespaces = namespaces.map((namespace) => {
       const username = USERNAME_FROM_PATH_REGEX.exec(namespace.subject)[1];
-      const userNamespaceDefinition = interpolateUsername(username, username, templateObject);
+      const userNamespaceDefinition = interpolateUsername(templateObject, username);
 
       userNamespaceDefinition.location = namespaceDefinition.id;
 
@@ -170,7 +170,7 @@ export default class BaseMCWSPersistenceProvider {
   async getRootNamespaces() {
     const user = await this.openmct.user.getCurrentUser();
     let rootNamespaces = await Promise.all(
-      this.roots.map((rootNamespace) => this.createIfMissing(user.id, rootNamespace))
+      this.roots.map((rootNamespace) => this.createIfMissing(rootNamespace, user.id))
     );
     rootNamespaces = rootNamespaces.filter(Boolean);
 
@@ -184,11 +184,11 @@ export default class BaseMCWSPersistenceProvider {
    * resolved with `undefined`.
    *
    * @private
-   * @param {string} userId the user ID
    * @param {NamespaceDefinition} namespaceDefinition
+   * @param {string} userId the user ID
    * @returns {Promise.<NamespaceDefinition>|Promise.<undefined>}
    */
-  async createIfMissing(userId, namespaceDefinition) {
+  async createIfMissing(namespaceDefinition, userId) {
     const namespace = mcws.namespace(namespaceDefinition.url);
 
     try {

--- a/src/persistence/BaseMCWSPersistenceProvider.js
+++ b/src/persistence/BaseMCWSPersistenceProvider.js
@@ -117,7 +117,7 @@ export default class BaseMCWSPersistenceProvider {
 
     const user = await this.openmct.user.getCurrentUser();
     const containedNamespaces = await this.getNamespacesFromMCWS(namespaceDefinition);
-    const userNamespace = interpolateUsername(namespaceTemplate, user.name, user.id);
+    const userNamespace = interpolateUsername(user.id, user.name, namespaceTemplate);
     const existingUserNamespace = containedNamespaces.find(
       (namespace) => namespace.url === userNamespace.url
     );
@@ -131,7 +131,7 @@ export default class BaseMCWSPersistenceProvider {
 
     containedNamespaces.unshift(userNamespace);
 
-    await this.createIfMissing(userNamespace, user.id, user.name);
+    await this.createIfMissing(user.id, userNamespace);
 
     return containedNamespaces;
   }
@@ -150,7 +150,7 @@ export default class BaseMCWSPersistenceProvider {
     const templateObject = namespaceDefinition.childTemplate;
     const userNamespaces = namespaces.map((namespace) => {
       const username = USERNAME_FROM_PATH_REGEX.exec(namespace.subject)[1];
-      const userNamespaceDefinition = interpolateUsername(templateObject, username, username);
+      const userNamespaceDefinition = interpolateUsername(username, username, templateObject);
 
       userNamespaceDefinition.location = namespaceDefinition.id;
 
@@ -170,7 +170,7 @@ export default class BaseMCWSPersistenceProvider {
   async getRootNamespaces() {
     const user = await this.openmct.user.getCurrentUser();
     let rootNamespaces = await Promise.all(
-      this.roots.map((rootNamespace) => this.createIfMissing(rootNamespace, user.id, user.name))
+      this.roots.map((rootNamespace) => this.createIfMissing(user.id, rootNamespace))
     );
     rootNamespaces = rootNamespaces.filter(Boolean);
 
@@ -184,10 +184,11 @@ export default class BaseMCWSPersistenceProvider {
    * resolved with `undefined`.
    *
    * @private
+   * @param {string} userId the user ID
    * @param {NamespaceDefinition} namespaceDefinition
    * @returns {Promise.<NamespaceDefinition>|Promise.<undefined>}
    */
-  async createIfMissing(namespaceDefinition, userId, userName) {
+  async createIfMissing(userId, namespaceDefinition) {
     const namespace = mcws.namespace(namespaceDefinition.url);
 
     try {

--- a/src/persistence/BaseMCWSPersistenceProvider.js
+++ b/src/persistence/BaseMCWSPersistenceProvider.js
@@ -107,7 +107,7 @@ export default class BaseMCWSPersistenceProvider {
 
     const user = await this.openmct.user.getCurrentUser();
     const containedNamespaces = await this.getNamespacesFromMCWS(namespaceDefinition);
-    const userNamespace = interpolateUsername(namespaceTemplate, user.id);
+    const userNamespace = interpolateUsername(namespaceTemplate, user.name, user.id);
     const existingUserNamespace = containedNamespaces.find(
       (namespace) => namespace.url === userNamespace.url
     );
@@ -121,7 +121,7 @@ export default class BaseMCWSPersistenceProvider {
 
     containedNamespaces.unshift(userNamespace);
 
-    await this.createIfMissing(userNamespace, user.id);
+    await this.createIfMissing(userNamespace, user.id, user.name);
 
     return containedNamespaces;
   }
@@ -140,7 +140,7 @@ export default class BaseMCWSPersistenceProvider {
     const templateObject = namespaceDefinition.childTemplate;
     const userNamespaces = namespaces.map((namespace) => {
       const username = USERNAME_FROM_PATH_REGEX.exec(namespace.subject)[1];
-      const userNamespaceDefinition = interpolateUsername(templateObject, username);
+      const userNamespaceDefinition = interpolateUsername(templateObject, username, username);
 
       userNamespaceDefinition.location = namespaceDefinition.id;
 
@@ -160,7 +160,7 @@ export default class BaseMCWSPersistenceProvider {
   async getRootNamespaces() {
     const user = await this.openmct.user.getCurrentUser();
     let rootNamespaces = await Promise.all(
-      this.roots.map((rootNamespace) => this.createIfMissing(rootNamespace, user.id))
+      this.roots.map((rootNamespace) => this.createIfMissing(rootNamespace, user.id, user.name))
     );
     rootNamespaces = rootNamespaces.filter(Boolean);
 
@@ -177,7 +177,7 @@ export default class BaseMCWSPersistenceProvider {
    * @param {NamespaceDefinition} namespaceDefinition
    * @returns {Promise.<NamespaceDefinition>|Promise.<undefined>}
    */
-  async createIfMissing(namespaceDefinition, userId) {
+  async createIfMissing(namespaceDefinition, userId, userName) {
     const namespace = mcws.namespace(namespaceDefinition.url);
 
     try {

--- a/src/persistence/oldPersistenceFolderInterceptor.js
+++ b/src/persistence/oldPersistenceFolderInterceptor.js
@@ -47,7 +47,7 @@ export default async function oldPersistenceFolderInterceptor(
       ) {
         userId = identifier.namespace.match(userKeyRegex)[1];
 
-        namespaceDefinition = interpolateUsername(userId, userId, usersNamespace.childTemplate);
+        namespaceDefinition = interpolateUsername(usersNamespace.childTemplate, userId);
         namespaceDefinition.location = usersNamespace.id;
       } else {
         namespaceDefinition = findNamespaceDefinition(namespaces, identifier) || { key: 'default' };

--- a/src/persistence/oldPersistenceFolderInterceptor.js
+++ b/src/persistence/oldPersistenceFolderInterceptor.js
@@ -47,7 +47,7 @@ export default async function oldPersistenceFolderInterceptor(
       ) {
         userId = identifier.namespace.match(userKeyRegex)[1];
 
-        namespaceDefinition = interpolateUsername(usersNamespace.childTemplate, userId);
+        namespaceDefinition = interpolateUsername(userId, userId, usersNamespace.childTemplate);
         namespaceDefinition.location = usersNamespace.id;
       } else {
         namespaceDefinition = findNamespaceDefinition(namespaces, identifier) || { key: 'default' };

--- a/src/persistence/test/MCWSNamespaceServiceSpec.js
+++ b/src/persistence/test/MCWSNamespaceServiceSpec.js
@@ -99,10 +99,10 @@ describe('MCWSNamespaceService', () => {
       url: '/some/personal/namespace',
       containsNamespaces: true,
       childTemplate: {
-        id: 'personal-${USER}:root',
-        key: 'personal-${USER}',
-        name: '${USER}',
-        url: '/some/personal/namespace/${USER}'
+        id: 'personal-${USERID}:root',
+        key: 'personal-${USERID}',
+        name: '${USERNAME}',
+        url: '/some/personal/namespace/${USERID}'
       }
     };
     inaccessibleContainerRootDefinition = {
@@ -112,10 +112,10 @@ describe('MCWSNamespaceService', () => {
       url: '/inaccessible/personal/namespace',
       containsNamespaces: true,
       childTemplate: {
-        id: 'inaccessible-personal-${USER}:root',
-        key: 'inaccessible-personal-${USER}',
-        name: '${USER}',
-        url: '/inaccessible/personal/namespace/${USER}'
+        id: 'inaccessible-personal-${USERID}:root',
+        key: 'inaccessible-personal-${USERID}',
+        name: '${USERNAME}',
+        url: '/inaccessible/personal/namespace/${USERID}'
       }
     };
     missingContainerRootDefinition = {
@@ -125,10 +125,10 @@ describe('MCWSNamespaceService', () => {
       url: '/missing/personal/namespace',
       containsNamespaces: true,
       childTemplate: {
-        id: 'missing-personal-${USER}:root',
-        key: 'missing-personal-${USER}',
-        name: '${USER}',
-        url: '/missing/personal/namespace/${USER}'
+        id: 'missing-personal-${USERID}:root',
+        key: 'missing-personal-${USERID}',
+        name: '${USERNAME}',
+        url: '/missing/personal/namespace/${USERID}'
       }
     };
 

--- a/src/persistence/utils.js
+++ b/src/persistence/utils.js
@@ -47,10 +47,10 @@ export function createNamespace(namespace) {
       url: namespace.url,
       containsNamespaces: true,
       childTemplate: {
-        id: namespace.key + '-${USER}' + ROOT_NAMESPACE_SUFFIX,
-        key: namespace.key + '-${USER}',
-        name: '${USER}',
-        url: namespace.url + '/${USER}'
+        id: namespace.key + '-${USERID}' + ROOT_NAMESPACE_SUFFIX,
+        key: namespace.key + '-${USERID}',
+        name: '${USERNAME}',
+        url: namespace.url + '/${USERID}'
       }
     };
   } else {
@@ -65,18 +65,19 @@ export function createNamespace(namespace) {
 
 /**
  * Interpolate a username with all values in a supplied object, replacing
- * '${USER}' with the supplied username.
+ * '${USERNAME}' with the supplied username and '${USERID} with the
+ *  supplied user ID.
  *
  * @private
  * @param {NamespaceTemplate} templateObject namespace template object.
  * @param {string} username a username.
  * @returns {NamespaceDefinition} a namespace definition object.
  */
-export function interpolateUsername(templateObject, username) {
+export function interpolateUsername(templateObject, username, userId) {
   const namespaceDefinition = {};
 
   Object.keys(templateObject).forEach((key) => {
-    namespaceDefinition[key] = templateObject[key].replace('${USER}', username);
+    namespaceDefinition[key] = templateObject[key].replace('${USERNAME}', username).replace('${USERID}', userId);
   });
 
   return namespaceDefinition;

--- a/src/persistence/utils.js
+++ b/src/persistence/utils.js
@@ -69,12 +69,12 @@ export function createNamespace(namespace) {
  * supplied user ID.
  *
  * @private
- * @param {string} userId the user ID
- * @param {string} username the username
  * @param {NamespaceTemplate} templateObject namespace template object.
+ * @param {string} userId the user ID
+ * @param {string} username the username (default is userId)
  * @returns {NamespaceDefinition} a namespace definition object.
  */
-export function interpolateUsername(userId, username, templateObject) {
+export function interpolateUsername(templateObject, userId, username = userId) {
   const namespaceDefinition = {};
 
   Object.keys(templateObject).forEach((key) => {

--- a/src/persistence/utils.js
+++ b/src/persistence/utils.js
@@ -65,15 +65,16 @@ export function createNamespace(namespace) {
 
 /**
  * Interpolate a username with all values in a supplied object, replacing
- * '${USERNAME}' with the supplied username and '${USERID} with the
- *  supplied user ID.
+ * '${USERNAME}' with the supplied username and '${USERID}' with the
+ * supplied user ID.
  *
  * @private
+ * @param {string} userId the user ID
+ * @param {string} username the username
  * @param {NamespaceTemplate} templateObject namespace template object.
- * @param {string} username a username.
  * @returns {NamespaceDefinition} a namespace definition object.
  */
-export function interpolateUsername(templateObject, username, userId) {
+export function interpolateUsername(userId, username, templateObject) {
   const namespaceDefinition = {};
 
   Object.keys(templateObject).forEach((key) => {

--- a/src/services/identity/createMCWSUser.js
+++ b/src/services/identity/createMCWSUser.js
@@ -8,7 +8,7 @@ export default function createMCWSUser(UserClass) {
      * @param {MCWSUserInfo} userInfo
      */
     constructor(name) {
-      super(name, name); // no id is returned, so we use name twice
+      super(String(name).replace(/[^a-zA-Z0-9]/g, ''), name);
     }
   };
 }


### PR DESCRIPTION
Fixes: https://github.com/NASA-AMMOS/openmct-mcws/issues/387 in v5.3.2. 

This can't be tested with development storage, so you'll need something to emulate the MCWS persistence storage, as well as send a poorly-formatted name. 


1. clone https://github.jpl.nasa.gov/IEMS/iems-gds-fast-mcws-persistence
3. cd into iems-gds-fast-mcws-persistence
4. edit the following file: fastmio/fastMIOServer.py line 165
5. replace remote_user='unknown' with remote_user='Unknown, User (999A)'
6. edit the following file: fastmio/config/fastmio.cfg
Line 26: 
`import_mcws_namespaces = true -> import_mcws_namespaces = false`
Line 40: 
`import_fastmio_namespaces=false -> import_fastmio_namespaces=true`

Lines 44-48: 

>ns_map= {
>        "/shared":"/home/user/shared",
>        "/systems":"/home/user/systems",
>        "/users":"/home/user/users"
>        }

becomes

>ns_map= {
>        "/shared":"/your/path/here/shared",
>        "/users":"/your/path/here/users"
>        }

7. Create a python3 virtual environment and install fastmio's required packeges. 

>python3 -m venv fastmioenv
>source fastmioenv/bin/activate
>pip install -e .


Fastmio is now configured to send your development server a MCWS namespace with an invalid ID. 

Run fast mio with python fastmio/fastMIOServer.py and leave the terminal up for your testing purposes. 

Note that you may need to delete the contents of <path to your local test users dir> while you test - fastmio will automatically pick up any changes to the and does not need to be restarted if you do. 


Next, configure the webpack dev environment and config.js to use the fastmio environment you just set up.  

Webpack dev: 
set your API_URL environment variable to localhost:8093 

config.js 

1. set the mcwsUrl to: 
`mcwsUrl: 'http://localhost:8093/mcws',`
2. Set the URLs for the development namespaces like so: 
3.  
>namespaces: [
>      {
>        key: 'r50-dev',
>        name: 'R5.0 Shared',
>        url: '/fastmio/shared'
>      },
>      {
>        userNamespace: true,
>        key: 'r50-dev',
>        name: 'R5.0 Users',
>        url: '/fastmio/users'
>      }
>    ],

uncomment the proxyUrl line, but do not uncomment the useDeveloperStorage line, as we're going to use fastmio in this scenario as our test storage provider. Don't forget to remove the comma after useDeveloperStorage if it is now the last item in the config file. 

running npm start should now run MCT as a developer server but with fastmio providing a fully qualified mcws-like name, allowing this functionality to be tested .


Verify that the user folder is automatically created with the full user name and that the logged in user in the MCT status bar is the correct user name. 
Verify that if you create an object in the user's folder, the namespace and location parameters do not contain spaces, commas, or other invalid characters. 
Verify that you can create objects in the shared folder with no issues as well. 
        
        
