### PR TITLE
392 force uppercase module subscriptions

### DIFF
--- a/src/realtime/MCWSEVRLevelStreamProvider.js
+++ b/src/realtime/MCWSEVRLevelStreamProvider.js
@@ -31,7 +31,7 @@ class MCWSEVRLevelStreamProvider extends MCWSStreamProvider {
    * @returns {String} The key
    */
   getKey(domainObject) {
-    return domainObject.telemetry.level;
+    return domainObject.telemetry.level.toUpperCase();
   }
 }
 

--- a/src/realtime/MCWSEVRLevelStreamProvider.js
+++ b/src/realtime/MCWSEVRLevelStreamProvider.js
@@ -31,6 +31,8 @@ class MCWSEVRLevelStreamProvider extends MCWSStreamProvider {
    * @returns {String} The key
    */
   getKey(domainObject) {
+    // only uppercase works for all mcws apis (lowercase will not work)
+    // see https://github.com/NASA-AMMOS/openmct-mcws/pull/412/changes
     return domainObject.telemetry.level.toUpperCase();
   }
 }

--- a/src/realtime/MCWSEVRStreamProvider.js
+++ b/src/realtime/MCWSEVRStreamProvider.js
@@ -33,21 +33,15 @@ class MCWSEVRStreamProvider extends MCWSStreamProvider {
   getKey(domainObject) {
     // Can subscribe only by EVR module even if subscribing by EVR
     // This is the default cause for EVRs that contain a module.
-    let module =
-      domainObject.telemetry &&
-      domainObject.telemetry.definition &&
-      domainObject.telemetry.definition.module &&
-      domainObject.telemetry.definition.module.toUpperCase();
+    let module = domainObject?.telemetry?.definition?.module?.toUpperCase();
 
-      // This is the top-level vista.evrModule object, which contains 
-      // A module definition but not in the definition object.  
-      // This must be captured before an attempt at legacy EVRs is made
-      // in case the module has underscores in it. 
-      if (!module || module.length <= 0) {
-          module = domainObject.telemetry
-              && domainObject.telemetry.module
-              && domainObject.telemetry.module.toUpperCase();
-      }
+    // This is the top-level vista.evrModule object, which contains
+    // a module definition but not in the definition object.
+    // This must be captured before attempting legacy EVRs,
+    // in case the module contains underscores.
+    if (!module?.length) {
+        module = domainObject?.telemetry?.module?.toUpperCase();
+    }
 
     // legacy inference of module by evr_name
     // This should *never* occur with modern telemetry dictionaries.

--- a/src/realtime/MCWSEVRStreamProvider.js
+++ b/src/realtime/MCWSEVRStreamProvider.js
@@ -33,12 +33,16 @@ class MCWSEVRStreamProvider extends MCWSStreamProvider {
   getKey(domainObject) {
     // Can subscribe only by EVR module even if subscribing by EVR
     // This is the default cause for EVRs that contain a module.
+    // only uppercase works for all mcws apis (lowercase will not work)
+    // see https://github.com/NASA-AMMOS/openmct-mcws/pull/412/changes
     let module = domainObject?.telemetry?.definition?.module?.toUpperCase();
 
     // This is the top-level vista.evrModule object, which contains
     // a module definition but not in the definition object.
     // This must be captured before attempting legacy EVRs,
     // in case the module contains underscores.
+    // only uppercase works for all mcws apis (lowercase will not work)
+    // see https://github.com/NASA-AMMOS/openmct-mcws/pull/412/changes
     if (!module?.length) {
         module = domainObject?.telemetry?.module?.toUpperCase();
     }
@@ -47,8 +51,10 @@ class MCWSEVRStreamProvider extends MCWSStreamProvider {
     // This should *never* occur with modern telemetry dictionaries.
     if (!module || module.length <= 0) {
       console.warn('Legacy domain objects should not be used anymore!');
+      // only uppercase works for all mcws apis (lowercase will not work)
+      // see https://github.com/NASA-AMMOS/openmct-mcws/pull/412/changes
       module = domainObject.telemetry.evr_name.split('_')[0].toUpperCase();
-    }
+  }
 
     return module;
   }

--- a/src/realtime/MCWSEVRStreamProvider.js
+++ b/src/realtime/MCWSEVRStreamProvider.js
@@ -32,19 +32,28 @@ class MCWSEVRStreamProvider extends MCWSStreamProvider {
    */
   getKey(domainObject) {
     // Can subscribe only by EVR module even if subscribing by EVR
+    // This is the default cause for EVRs that contain a module.
     let module =
       domainObject.telemetry &&
       domainObject.telemetry.definition &&
       domainObject.telemetry.definition.module &&
-      domainObject.telemetry.definition.module.toLowerCase();
+      domainObject.telemetry.definition.module.toUpperCase();
+
+      // This is the top-level vista.evrModule object, which contains 
+      // A module definition but not in the definition object.  
+      // This must be captured before an attempt at legacy EVRs is made
+      // in case the module has underscores in it. 
+      if (!module || module.length <= 0) {
+          module = domainObject.telemetry
+              && domainObject.telemetry.module
+              && domainObject.telemetry.module.toUpperCase();
+      }
 
     // legacy inference of module by evr_name
-    // if this fallback is used will break on module names containing underscores
+    // This should *never* occur with modern telemetry dictionaries.
     if (!module || module.length <= 0) {
       console.warn('Legacy domain objects should not be used anymore!');
-      module = domainObject.telemetry.evr_name
-        ? domainObject.telemetry.evr_name.split('_')[0].toLowerCase()
-        : domainObject.telemetry.module.toLowerCase();
+      module = domainObject.telemetry.evr_name.split('_')[0].toUpperCase();
     }
 
     return module;

--- a/src/realtime/MCWSStreamWorkerScript.js
+++ b/src/realtime/MCWSStreamWorkerScript.js
@@ -212,6 +212,8 @@
         const data = JSON.parse(message.data);
 
         data.forEach((datum) => {
+          // only uppercase works for all mcws apis (lowercase will not work)
+          // see https://github.com/NASA-AMMOS/openmct-mcws/pull/412/changes
           const key = datum[property].toUpperCase();
 
           if (subscribers[key] > 0) {

--- a/src/realtime/MCWSStreamWorkerScript.js
+++ b/src/realtime/MCWSStreamWorkerScript.js
@@ -212,7 +212,7 @@
         const data = JSON.parse(message.data);
 
         data.forEach((datum) => {
-          const key = datum[property];
+          const key = datum[property].toUpperCase();
 
           if (subscribers[key] > 0) {
             self.postMessage({


### PR DESCRIPTION
Fixes: https://github.com/NASA-AMMOS/openmct-mcws/issues/392

1. Corrects order of operations in assigning a module to an EVR stream request. 

Before: 
domainObject.telemetry.definition.module first
domainObject.telemetry.evr_name.split("_")[0] if evr_name existed
domainObject.telemetry.module third

This caused it to break if modules had an underscore in them, and would also cause it to default to the legacy EVR name method before using the module definition from the dictionary. 

Now: 
domainObject.telemetry.definition.module first
domainObject.telemetry.module second
domainObject.telemetry.evr_name.split("_")[0] as a last ditch resort. 

This should work for cases where the module has underscores now, as the module provided by the EVR dictionary will be used in all cases before trying to assume a module from the evr name. 

2. Makes module stream requests all caps and all internally consistent. 
There were instances where an EVR return would have an all caps module name, but OMM was forcing all lowercase module names in the evr stream. This caused a disconnect with the MCWS return so no EVRs would appear in module streams. 

MCWS is case-agnostic for EVR streams, so best method here is to make stream requests internally consistent - other filters use all caps already (well, they use the dictionary default which is all caps), so we should also use it for both the request and the key. 