### PR TITLE
Fix `net::ERR_INSUFFICIENT_RESOURCES` errors on HTTP2 introduced in 5.4.0

### DIFF
--- a/src/persistence/BaseMCWSPersistenceProvider.js
+++ b/src/persistence/BaseMCWSPersistenceProvider.js
@@ -59,15 +59,25 @@ export default class BaseMCWSPersistenceProvider {
    * @returns {Promise.<NamespaceDefinition[]>} persistenceNamespaces
    */
   async getPersistenceNamespaces() {
-    // get root namespaces, get contained namespaces.
-    if (!this.persistenceNamespaces) {
-      const rootNamespaces = await this.getRootNamespaces();
-      const allContainedNamespaces = await this.getAllContainedNamespaces(rootNamespaces);
-
-      this.persistenceNamespaces = [...rootNamespaces, ...allContainedNamespaces];
+    // Return cached result if available
+    if (this.persistenceNamespaces) {
+      return this.persistenceNamespaces;
     }
 
-    return this.persistenceNamespaces;
+    // If initialization is in progress, wait for it
+    if (!this.persistenceNamespacesPromise) {
+      this.persistenceNamespacesPromise = (async () => {
+        const rootNamespaces = await this.getRootNamespaces();
+        const allContainedNamespaces = await this.getAllContainedNamespaces(rootNamespaces);
+
+        this.persistenceNamespaces = [...rootNamespaces, ...allContainedNamespaces];
+        delete this.persistenceNamespacesPromise;
+
+        return this.persistenceNamespaces;
+      })();
+    }
+
+    return this.persistenceNamespacesPromise;
   }
 
   /**

--- a/src/services/mcws/MCWSClient.js
+++ b/src/services/mcws/MCWSClient.js
@@ -60,9 +60,6 @@ class MCWSClient {
       delete options.params;
     }
 
-    // Keepalive
-    options.keepalive = true;
-
     try {
       response = await fetch(url, options);
     } catch (error) {


### PR DESCRIPTION
fixes: #373 

Main fix here is the removal of `keapalive = true` for fetch options. This was introduced to increase load times and testing seemed to indicate it did, though now it's believed that was a false positive. This flag will crush Open MCT using the MCWS Adapter plugin on large quantities of requests. The fix is to remove. We'll do testing to ensure load times aren't affected. Additional fixes for race conditions introduced in trying to fix the underlying issue are included as well as they are good changes.