### PR TITLE
Update SonarCloud Scan version in GitHub Actions

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -138,6 +138,6 @@ jobs:
         name: codeql-artifacts
         path: ${{ env.RESULTS_DIR }}
     - name: SonarCloud Scan
-      uses: SonarSource/sonarqube-scan-action@v5
+      uses: SonarSource/sonarqube-scan-action@v6
       env:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
closes #416 

This is due to a security vulnerability.