### PR TITLE
5.4.1 Patch: Fix `net::ERR_INSUFFICIENT_RESOURCES` errors on HTTP2 introduced in 5.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmct-mcws",
-  "version": "v5.4.0",
+  "version": "v5.4.1",
   "description": "Open MCT for MCWS",
   "devDependencies": {
     "@babel/eslint-parser": "7.26.8",

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>gov.nasa.arc.wtd</groupId>
     <artifactId>openmct-client</artifactId>
     <name>Open MCT for MCWS Client</name>
-    <version>v5.4.0</version>
+    <version>v5.4.1</version>
     <packaging>war</packaging>
 
     <properties>

--- a/src/persistence/BaseMCWSPersistenceProvider.js
+++ b/src/persistence/BaseMCWSPersistenceProvider.js
@@ -57,15 +57,25 @@ export default class BaseMCWSPersistenceProvider {
    * @returns {Promise.<NamespaceDefinition[]>} persistenceNamespaces
    */
   async getPersistenceNamespaces() {
-    // get root namespaces, get contained namespaces.
-    if (!this.persistenceNamespaces) {
-      const rootNamespaces = await this.getRootNamespaces();
-      const allContainedNamespaces = await this.getAllContainedNamespaces(rootNamespaces);
-
-      this.persistenceNamespaces = [...rootNamespaces, ...allContainedNamespaces];
+    // Return cached result if available
+    if (this.persistenceNamespaces) {
+      return this.persistenceNamespaces;
     }
 
-    return this.persistenceNamespaces;
+    // If initialization is in progress, wait for it
+    if (!this.persistenceNamespacesPromise) {
+      this.persistenceNamespacesPromise = (async () => {
+        const rootNamespaces = await this.getRootNamespaces();
+        const allContainedNamespaces = await this.getAllContainedNamespaces(rootNamespaces);
+
+        this.persistenceNamespaces = [...rootNamespaces, ...allContainedNamespaces];
+        delete this.persistenceNamespacesPromise;
+
+        return this.persistenceNamespaces;
+      })();
+    }
+
+    return this.persistenceNamespacesPromise;
   }
 
   /**

--- a/src/services/mcws/MCWSClient.js
+++ b/src/services/mcws/MCWSClient.js
@@ -60,9 +60,6 @@ class MCWSClient {
       delete options.params;
     }
 
-    // Keepalive
-    options.keepalive = true;
-
     try {
       response = await fetch(url, options);
     } catch (error) {


### PR DESCRIPTION
fixes #373 for `release/5.4.1`
Applies fixes from: https://github.com/NASA-AMMOS/openmct-mcws/pull/415

This will fix `net::ERR_INSUFFICIENT_RESOURCES` errors when using HTTP/2.