### PR TITLE
Add optional runtime config

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -45,8 +45,23 @@ import RealtimeSessions from './src/realtimeSessions/plugin.js';
 import GlobalFilters from './src/globalFilters/plugin.js';
 import ExportDataAction from './src/exportDataAction/plugin.js';
 
+// optional runtime config
+let runtimeConfig = {};
+
+try {
+  const response = await fetch('./config.json', { cache: 'no-store' });
+
+  if (response.ok) {
+    runtimeConfig = await response.json();
+  } else if (response.status !== 404) {
+    console.warn(`Unable to load config.json: ${response.status}`);
+  }
+} catch (error) {
+  console.warn('Unable to load config.json', error);
+}
+
 export default function openmctMCWSPlugin(options) {
-  return function install(openmct) {
+  return async function install(openmct) {
     const defaultConfig = {
       venueAware: {
         enabled: false,
@@ -156,7 +171,9 @@ export default function openmctMCWSPlugin(options) {
       return item && typeof item === 'object' && !Array.isArray(item);
     }
 
-    const config = deepMerge(defaultConfig, options || {});
+    // order of precedence: runtimeConfig, recipeConfig, defaultConfig
+    const recipeConfig = options || {};
+    const config = deepMerge(defaultConfig, deepMerge(recipeConfig, runtimeConfig));
 
     if (config.useDeveloperStorage === undefined) {
       // Attempt to define a reasonable default for developer storage that supports Open MCT build tool

--- a/plugin.js
+++ b/plugin.js
@@ -49,15 +49,15 @@ import ExportDataAction from './src/exportDataAction/plugin.js';
 let runtimeConfig = {};
 
 try {
-  const response = await fetch('./config.json', { cache: 'no-store' });
+  const response = await fetch('./mcws-config.json', { cache: 'no-store' });
 
   if (response.ok) {
     runtimeConfig = await response.json();
   } else if (response.status !== 404) {
-    console.warn(`Unable to load config.json: ${response.status}`);
+    console.warn(`Unable to load mcws-config.json: ${response.status}`);
   }
 } catch (error) {
-  console.warn('Unable to load config.json', error);
+  console.warn('Unable to load mcws-config.json', error);
 }
 
 export default function openmctMCWSPlugin(options) {
@@ -171,9 +171,28 @@ export default function openmctMCWSPlugin(options) {
       return item && typeof item === 'object' && !Array.isArray(item);
     }
 
-    // order of precedence: runtimeConfig, recipeConfig, defaultConfig
+    // restrict the runtime config to only the keys that are allowed
+    // as well as making sure values are present
+    let restrictedRuntimeConfig = {};
+
+    if (runtimeConfig.mcwsUrl) {
+      restrictedRuntimeConfig.mcwsUrl = runtimeConfig.mcwsUrl;
+    }
+
+
+    if (Array.isArray(runtimeConfig.namespaces)) {
+      const filteredNamespaces = runtimeConfig.namespaces.filter(
+        namespace => namespace?.key && namespace.name && namespace.url
+      );
+
+      if (filteredNamespaces.length) {
+        restrictedRuntimeConfig.namespaces = filteredNamespaces;
+      }
+    }
+
     const recipeConfig = options || {};
-    const config = deepMerge(defaultConfig, deepMerge(recipeConfig, runtimeConfig));
+    // order of precedence: runtimeConfig, recipeConfig, defaultConfig
+    const config = deepMerge(defaultConfig, deepMerge(recipeConfig, restrictedRuntimeConfig));
 
     if (config.useDeveloperStorage === undefined) {
       // Attempt to define a reasonable default for developer storage that supports Open MCT build tool

--- a/plugin.js
+++ b/plugin.js
@@ -61,7 +61,7 @@ try {
 }
 
 export default function openmctMCWSPlugin(options) {
-  return async function install(openmct) {
+  return function install(openmct) {
     const defaultConfig = {
       venueAware: {
         enabled: false,


### PR DESCRIPTION
closes #419 

Added support for an optional runtime `config.json` at the root of a built Open MCT instance using the Open MCT for MCWS Plugin. This allows built release artifacts to be configured at deployment time without rebuilding or updating recipe configuration through the Open MCT build tool. Common runtime overrides include `mcwsUrl`, `namespaces`, and other MCWS plugin options.

Example `config.json`:
```json
{
  "mcwsUrl": "https://example.jpl.nasa.gov/mcws",
  "namespaces": [
    {
      "key": "mission",
      "name": "Mission Shared",
      "url": "/path/to/shared"
    },
    {
      "userNamespace": true,
      "key": "mission",
      "name": "Mission Users",
      "url": "/path/to/users"
    }
  ]
}
```

Config precedence is:
config.json > recipe config > plugin defaults
Only keys provided by a higher-precedence config override lower-precedence values. Omitted keys fall back to the recipe config, then plugin defaults.

Release artifacts include a `config.example.json` file. Users can copy or rename it to `config.json` and update its values if they want to provide runtime configuration overrides.