### PR TITLE
NPM Prep

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "dist/openmct-mcws-plugin.js",
   "type": "module",
   "files": [
-    "dist"
+    "dist",
+    "mcws-config.example.json",
+    "CONFIGURATION.md"
   ],
   "devDependencies": {
     "@babel/eslint-parser": "7.26.8",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Open MCT for MCWS",
   "main": "dist/openmct-mcws-plugin.js",
   "type": "module",
+  "files": [
+    "dist"
+  ],
   "devDependencies": {
     "@babel/eslint-parser": "7.26.8",
     "@braintree/sanitize-url": "6.0.4",


### PR DESCRIPTION
closes #440 

Adds a files property to our package.json which tells npm which files are needed in the package, this slightly reduces our packaged file size from ~1.9mb to ~1.7mb.

The final package will be:

```bash
CONFIGURATION.md
README.md
dist/
mcws-config.example.json
package.json
```
