### PR TITLE
Fix uppercasing stream keys breaking non-keyed realtime streams

### DIFF
--- a/src/realtime/MCWSStreamWorkerScript.js
+++ b/src/realtime/MCWSStreamWorkerScript.js
@@ -214,7 +214,7 @@
         data.forEach((datum) => {
           // only uppercase works for all mcws apis (lowercase will not work)
           // see https://github.com/NASA-AMMOS/openmct-mcws/pull/412/changes
-          const key = datum[property].toUpperCase();
+          const key = datum[property]?.toUpperCase();
 
           if (subscribers[key] > 0) {
             self.postMessage({


### PR DESCRIPTION
Additional fix for #392 

A fix to uppercase modules for subscription requests ([#392](https://github.com/NASA-AMMOS/openmct-mcws/issues/392) / [#412](https://github.com/NASA-AMMOS/openmct-mcws/pull/412)) inadvertently broke a previous bypass for requesting commands, data products, frame summary/events, packet summary, and some messages.