### PR TITLE
Fix subscription message listener overwriting and uppercase frame events subscription key

### DIFF
--- a/src/realtime/MCWSFrameEventStreamProvider.js
+++ b/src/realtime/MCWSFrameEventStreamProvider.js
@@ -22,7 +22,7 @@ class MCWSFrameEventStreamProvider extends MCWSStreamProvider {
   getKey(domainObject) {
     if (domainObject.type === 'vista.frame-event-filter') {
       const frameEventType = domainObject.identifier.key.split(':')[0];
-      return frameEventType;
+      return frameEventType.toUpperCase();
     } else {
       return undefined;
     }

--- a/src/realtime/MCWSStreamProvider.js
+++ b/src/realtime/MCWSStreamProvider.js
@@ -88,7 +88,7 @@ class MCWSStreamProvider {
   worker() {
     const worker = runMCWSStreamWorker();
 
-    worker.onmessage = this.onmessage.bind(this);
+    worker.addEventListener('message', this.onmessage.bind(this));
 
     // cache worker
     this.worker = function () {


### PR DESCRIPTION
related: #392 

The frame events subscription key was not being uppercased like the other subscription keys, so there'd be a mismatch breaking delivery of frame events telemetry. The MCWSStreamProvider was converted to singleton, which is godo for reducing threads, but we were overwriting the onmessage method with each new subscription, now we're adding listeners and no subscriptions are overwritten.